### PR TITLE
fix: avoid comment loss in enums and structs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ as tested on rust-analyzer's [crates][ra-crates]:
 [ra-crates]: https://github.com/rust-lang/rust-analyzer/blob/master/crates/syntax/src/ast/generated.rs
 
 <!-- just: conf-md -->
-**Summary:** +94,950 / -13,609
+**Summary:** +94,024 / -13,420
 
 | **Top 5 <del>Removed</del> Lines** | **Top 5 <ins>Added</ins> Lines** |
 |---|---|
@@ -42,23 +42,23 @@ as tested on rust-analyzer's [crates][ra-crates]:
 
 | Rank | Size Rank | Diff Rank | Impact |   +   |    -    | File |
 |------|-----------|-----------|--------|-------|---------|------|
-| 1 | 7 | 1 | 41.0% | 1,561 | 3,808 | [`rust_analyzer/src_config`](https://github.com/lmmx/chloro/blob/master/chloro-core/tests/conformance/snapshots/ra/rust_analyzer/src_config.diff) |
-| 2 | 2 | 11 | 3.9% | 248 | 6,437 | [`hir/src_lib`](https://github.com/lmmx/chloro/blob/master/chloro-core/tests/conformance/snapshots/ra/hir/src_lib.diff) |
+| 1 | 7 | 1 | 40.9% | 1,559 | 3,814 | [`rust_analyzer/src_config`](https://github.com/lmmx/chloro/blob/master/chloro-core/tests/conformance/snapshots/ra/rust_analyzer/src_config.diff) |
+| 2 | 2 | 11 | 3.8% | 245 | 6,440 | [`hir/src_lib`](https://github.com/lmmx/chloro/blob/master/chloro-core/tests/conformance/snapshots/ra/hir/src_lib.diff) |
 | 3 | 1 | 33 | 1.5% | 165 | 11,159 | [`ide/src_hover_tests`](https://github.com/lmmx/chloro/blob/master/chloro-core/tests/conformance/snapshots/ra/ide/src_hover_tests.diff) |
-| 4 | 3 | 17 | 3.6% | 216 | 6,084 | [`ide_assists/src_handlers_extract_function`](https://github.com/lmmx/chloro/blob/master/chloro-core/tests/conformance/snapshots/ra/ide_assists/src_handlers_extract_function.diff) |
+| 4 | 3 | 16 | 3.6% | 216 | 6,084 | [`ide_assists/src_handlers_extract_function`](https://github.com/lmmx/chloro/blob/master/chloro-core/tests/conformance/snapshots/ra/ide_assists/src_handlers_extract_function.diff) |
 | 5 | 15 | 5 | 12.4% | 373 | 3,020 | [`rust_analyzer/src_lsp_to_proto`](https://github.com/lmmx/chloro/blob/master/chloro-core/tests/conformance/snapshots/ra/rust_analyzer/src_lsp_to_proto.diff) |
-| 6 | 60 | 2 | 53.4% | 798 | 1,495 | [`hir_expand/src_builtin_derive_macro`](https://github.com/lmmx/chloro/blob/master/chloro-core/tests/conformance/snapshots/ra/hir_expand/src_builtin_derive_macro.diff) |
-| 7 | 6 | 20 | 5.1% | 201 | 3,916 | [`ide/src_goto_definition`](https://github.com/lmmx/chloro/blob/master/chloro-core/tests/conformance/snapshots/ra/ide/src_goto_definition.diff) |
+| 6 | 6 | 19 | 5.1% | 201 | 3,916 | [`ide/src_goto_definition`](https://github.com/lmmx/chloro/blob/master/chloro-core/tests/conformance/snapshots/ra/ide/src_goto_definition.diff) |
+| 7 | 60 | 2 | 53.4% | 798 | 1,495 | [`hir_expand/src_builtin_derive_macro`](https://github.com/lmmx/chloro/blob/master/chloro-core/tests/conformance/snapshots/ra/hir_expand/src_builtin_derive_macro.diff) |
 | 8 | 29 | 6 | 15.0% | 346 | 2,313 | [`hir_ty/src_next_solver_interner`](https://github.com/lmmx/chloro/blob/master/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_next_solver_interner.diff) |
 | 9 | 89 | 3 | 37.3% | 428 | 1,147 | [`ide/src_navigation_target`](https://github.com/lmmx/chloro/blob/master/chloro-core/tests/conformance/snapshots/ra/ide/src_navigation_target.diff) |
-| 10 | 68 | 4 | 30.7% | 422 | 1,373 | [`hir_def/src_lib`](https://github.com/lmmx/chloro/blob/master/chloro-core/tests/conformance/snapshots/ra/hir_def/src_lib.diff) |
+| 10 | 67 | 4 | 30.5% | 419 | 1,376 | [`hir_def/src_lib`](https://github.com/lmmx/chloro/blob/master/chloro-core/tests/conformance/snapshots/ra/hir_def/src_lib.diff) |
 | 11 | 41 | 7 | 17.8% | 335 | 1,882 | [`ide_assists/src_handlers_auto_import`](https://github.com/lmmx/chloro/blob/master/chloro-core/tests/conformance/snapshots/ra/ide_assists/src_handlers_auto_import.diff) |
 | 12 | 8 | 38 | 4.0% | 152 | 3,788 | [`ide/src_rename`](https://github.com/lmmx/chloro/blob/master/chloro-core/tests/conformance/snapshots/ra/ide/src_rename.diff) |
 | 13 | 14 | 31 | 5.6% | 171 | 3,066 | [`ide/src_references`](https://github.com/lmmx/chloro/blob/master/chloro-core/tests/conformance/snapshots/ra/ide/src_references.diff) |
-| 14 | 33 | 19 | 9.3% | 204 | 2,197 | [`ide_assists/src_handlers_add_missing_match_arms`](https://github.com/lmmx/chloro/blob/master/chloro-core/tests/conformance/snapshots/ra/ide_assists/src_handlers_add_missing_match_arms.diff) |
-| 15 | 13 | 56 | 4.0% | 124 | 3,099 | [`ide_assists/src_handlers_generate_function`](https://github.com/lmmx/chloro/blob/master/chloro-core/tests/conformance/snapshots/ra/ide_assists/src_handlers_generate_function.diff) |
+| 14 | 33 | 17 | 9.3% | 204 | 2,197 | [`ide_assists/src_handlers_add_missing_match_arms`](https://github.com/lmmx/chloro/blob/master/chloro-core/tests/conformance/snapshots/ra/ide_assists/src_handlers_add_missing_match_arms.diff) |
+| 15 | 13 | 57 | 4.0% | 123 | 3,100 | [`ide_assists/src_handlers_generate_function`](https://github.com/lmmx/chloro/blob/master/chloro-core/tests/conformance/snapshots/ra/ide_assists/src_handlers_generate_function.diff) |
 | 16 | 95 | 8 | 24.4% | 273 | 1,121 | [`rust_analyzer/tests_slow-tests_ratoml`](https://github.com/lmmx/chloro/blob/master/chloro-core/tests/conformance/snapshots/ra/rust_analyzer/tests_slow-tests_ratoml.diff) |
-| 17 | 44 | 21 | 10.5% | 193 | 1,838 | [`ide_assists/src_handlers_generate_delegate_trait`](https://github.com/lmmx/chloro/blob/master/chloro-core/tests/conformance/snapshots/ra/ide_assists/src_handlers_generate_delegate_trait.diff) |
+| 17 | 44 | 20 | 10.5% | 193 | 1,838 | [`ide_assists/src_handlers_generate_delegate_trait`](https://github.com/lmmx/chloro/blob/master/chloro-core/tests/conformance/snapshots/ra/ide_assists/src_handlers_generate_delegate_trait.diff) |
 | 18 | 19 | 50 | 5.0% | 132 | 2,635 | [`ide_assists/src_handlers_extract_variable`](https://github.com/lmmx/chloro/blob/master/chloro-core/tests/conformance/snapshots/ra/ide_assists/src_handlers_extract_variable.diff) |
 | 19 | 37 | 28 | 8.6% | 174 | 2,034 | [`ide_assists/src_handlers_destructure_tuple_binding`](https://github.com/lmmx/chloro/blob/master/chloro-core/tests/conformance/snapshots/ra/ide_assists/src_handlers_destructure_tuple_binding.diff) |
 | 20 | 11 | 97 | 2.8% | 90 | 3,270 | [`ide_completion/src_render`](https://github.com/lmmx/chloro/blob/master/chloro-core/tests/conformance/snapshots/ra/ide_completion/src_render.diff) |

--- a/chloro-core/src/formatter/node/common/fields.rs
+++ b/chloro-core/src/formatter/node/common/fields.rs
@@ -1,69 +1,74 @@
-// src/formatter/node/fields.rs
+// chloro-core/src/formatter/node/common/fields.rs
 use ra_ap_syntax::ast::{HasAttrs, HasDocComments, HasName, HasVisibility};
 use ra_ap_syntax::{AstNode, AstToken, NodeOrToken, SyntaxKind, ast};
 
-use crate::formatter::node::common::comments;
 use crate::formatter::write_indent;
+
+/// Collect non-doc comments from inside a node (before the name)
+fn collect_inner_comments(node: &ra_ap_syntax::SyntaxNode) -> Vec<String> {
+    let mut comments = Vec::new();
+
+    for child in node.children_with_tokens() {
+        match child {
+            NodeOrToken::Token(t) => {
+                if t.kind() == SyntaxKind::COMMENT {
+                    let text = t.text().to_string();
+                    // Skip doc comments (handled by HasDocComments)
+                    if !text.starts_with("///") && !text.starts_with("//!") {
+                        comments.push(text);
+                    }
+                }
+            }
+            NodeOrToken::Node(n) => {
+                // Stop when we hit the NAME node
+                if n.kind() == SyntaxKind::NAME {
+                    break;
+                }
+            }
+        }
+    }
+
+    comments
+}
 
 /// Format record fields with their comments (used by struct and enum variants).
 pub fn format_record_fields(fields: &ast::RecordFieldList, buf: &mut String, indent: usize) {
-    let children: Vec<_> = fields.syntax().children_with_tokens().collect();
-
-    for (idx, child) in children.iter().enumerate() {
-        match child {
-            NodeOrToken::Token(t) if t.kind() == SyntaxKind::COMMENT => {
-                // Check if this comment is attached to the next field
-                if !comments::is_comment_attached_to_next_field(&children, idx) {
-                    // Preserve blank line spacing before standalone comment
-                    if comments::should_have_blank_line_before_comment(&children, idx) {
-                        buf.push('\n');
-                    }
-                    write_indent(buf, indent);
-                    buf.push_str(t.text());
-                    buf.push('\n');
-                }
-            }
-            NodeOrToken::Node(n) if n.kind() == SyntaxKind::RECORD_FIELD => {
-                if let Some(field) = ast::RecordField::cast(n.clone()) {
-                    // Collect comments immediately before this field
-                    let preceding = comments::collect_preceding_comments_in_list(&children, idx);
-                    for comment in &preceding {
-                        write_indent(buf, indent);
-                        buf.push_str(comment);
-                        buf.push('\n');
-                    }
-
-                    // Format field doc comments
-                    for comment in field.doc_comments() {
-                        let text = comment.text();
-                        write_indent(buf, indent);
-                        buf.push_str(text.trim());
-                        buf.push('\n');
-                    }
-
-                    // Format field attributes
-                    for attr in field.attrs() {
-                        write_indent(buf, indent);
-                        buf.push_str(&attr.syntax().text().to_string());
-                        buf.push('\n');
-                    }
-
-                    write_indent(buf, indent);
-                    if let Some(vis) = field.visibility() {
-                        buf.push_str(&vis.syntax().text().to_string());
-                        buf.push(' ');
-                    }
-                    if let Some(name) = field.name() {
-                        buf.push_str(&name.text());
-                    }
-                    buf.push_str(": ");
-                    if let Some(ty) = field.ty() {
-                        buf.push_str(&ty.syntax().text().to_string());
-                    }
-                    buf.push_str(",\n");
-                }
-            }
-            _ => {}
+    for field in fields.fields() {
+        // Collect comments from inside the field node (before the name)
+        let comments_before = collect_inner_comments(field.syntax());
+        for comment in &comments_before {
+            write_indent(buf, indent);
+            buf.push_str(comment);
+            buf.push('\n');
         }
+
+        // Format field doc comments
+        for comment in field.doc_comments() {
+            let text = comment.text();
+            write_indent(buf, indent);
+            buf.push_str(text.trim());
+            buf.push('\n');
+        }
+
+        // Format field attributes
+        for attr in field.attrs() {
+            write_indent(buf, indent);
+            buf.push_str(&attr.syntax().text().to_string());
+            buf.push('\n');
+        }
+
+        write_indent(buf, indent);
+        if let Some(vis) = field.visibility() {
+            buf.push_str(&vis.syntax().text().to_string());
+            buf.push(' ');
+        }
+        if let Some(name) = field.name() {
+            buf.push_str(&name.text());
+        }
+        buf.push_str(": ");
+        if let Some(ty) = field.ty() {
+            buf.push_str(&ty.syntax().text().to_string());
+        }
+        buf.push_str(",\n");
     }
 }

--- a/chloro-core/src/formatter/node/enumdef.rs
+++ b/chloro-core/src/formatter/node/enumdef.rs
@@ -4,8 +4,59 @@ use ra_ap_syntax::{
     ast::{self, HasAttrs, HasDocComments, HasName, HasVisibility},
 };
 
-use crate::formatter::node::common::{comments, fields, header};
+use crate::formatter::node::common::{fields, header};
 use crate::formatter::write_indent;
+
+/// Collect non-doc comments from inside a variant node (before the name)
+fn collect_inner_comments(node: &SyntaxNode) -> Vec<String> {
+    let mut comments = Vec::new();
+
+    for child in node.children_with_tokens() {
+        match child {
+            NodeOrToken::Token(t) => {
+                if t.kind() == SyntaxKind::COMMENT {
+                    let text = t.text().to_string();
+                    // Skip doc comments (handled by HasDocComments)
+                    if !text.starts_with("///") && !text.starts_with("//!") {
+                        comments.push(text);
+                    }
+                }
+            }
+            NodeOrToken::Node(n) => {
+                // Stop when we hit the NAME node - comments after that are trailing
+                if n.kind() == SyntaxKind::NAME {
+                    break;
+                }
+            }
+        }
+    }
+
+    comments
+}
+
+/// Check if there's a blank line before this node (looking at preceding siblings)
+fn has_blank_line_before(node: &SyntaxNode) -> bool {
+    let mut current = node.prev_sibling_or_token();
+
+    while let Some(item) = current {
+        match &item {
+            NodeOrToken::Token(t) => {
+                if t.kind() == SyntaxKind::WHITESPACE {
+                    if t.text().matches('\n').count() >= 2 {
+                        return true;
+                    }
+                } else if t.kind() == SyntaxKind::COMMENT || t.kind() == SyntaxKind::COMMA {
+                    // Continue past comments and commas
+                } else {
+                    return false;
+                }
+                current = t.prev_sibling_or_token();
+            }
+            NodeOrToken::Node(_) => return false,
+        }
+    }
+    false
+}
 
 pub fn format_enum(node: &SyntaxNode, buf: &mut String, indent: usize) {
     let enum_ = match ast::Enum::cast(node.clone()) {
@@ -19,92 +70,69 @@ pub fn format_enum(node: &SyntaxNode, buf: &mut String, indent: usize) {
     if let Some(variants) = enum_.variant_list() {
         buf.push_str(" {\n");
 
-        // Process children to handle comments between variants
-        let children: Vec<_> = variants.syntax().children_with_tokens().collect();
+        let mut first_variant = true;
 
-        for (idx, child) in children.iter().enumerate() {
-            match child {
-                NodeOrToken::Token(t) if t.kind() == SyntaxKind::COMMENT => {
-                    // If not attached to next variant, print standalone comment
-                    if !comments::is_comment_attached_to_next_variant(&children, idx) {
-                        if comments::should_have_blank_line_before_comment(&children, idx) {
-                            buf.push('\n');
-                        }
+        for variant in variants.variants() {
+            // Check for blank line before this variant (to preserve spacing)
+            if !first_variant && has_blank_line_before(variant.syntax()) {
+                buf.push('\n');
+            }
+
+            // Collect comments from inside the variant node (before the name)
+            let comments_before = collect_inner_comments(variant.syntax());
+            for comment in &comments_before {
+                write_indent(buf, indent + 4);
+                buf.push_str(comment);
+                buf.push('\n');
+            }
+
+            // Variant doc comments (///)
+            for doc_comment in variant.doc_comments() {
+                write_indent(buf, indent + 4);
+                buf.push_str(doc_comment.text().trim());
+                buf.push('\n');
+            }
+
+            // Variant attributes
+            for attr in variant.attrs() {
+                write_indent(buf, indent + 4);
+                buf.push_str(&attr.syntax().text().to_string());
+                buf.push('\n');
+            }
+
+            write_indent(buf, indent + 4);
+            if let Some(name) = variant.name() {
+                buf.push_str(&name.text());
+            }
+            if let Some(field_list) = variant.field_list() {
+                match field_list {
+                    ast::FieldList::RecordFieldList(record_fields) => {
+                        buf.push_str(" {\n");
+                        fields::format_record_fields(&record_fields, buf, indent + 8);
                         write_indent(buf, indent + 4);
-                        buf.push_str(t.text());
-                        buf.push('\n');
+                        buf.push('}');
                     }
-                }
-                NodeOrToken::Node(n) if n.kind() == SyntaxKind::VARIANT => {
-                    if let Some(variant) = ast::Variant::cast(n.clone()) {
-                        // Comments immediately before this variant
-                        let comments_before =
-                            comments::collect_preceding_comments_in_list(&children, idx);
-                        for comment in &comments_before {
-                            write_indent(buf, indent + 4);
-                            buf.push_str(comment);
-                            buf.push('\n');
-                        }
-
-                        // Variant doc comments (///)
-                        for doc_comment in variant.doc_comments() {
-                            write_indent(buf, indent + 4);
-                            buf.push_str(doc_comment.text().trim());
-                            buf.push('\n');
-                        }
-
-                        // Variant attributes
-                        for attr in variant.attrs() {
-                            write_indent(buf, indent + 4);
-                            buf.push_str(&attr.syntax().text().to_string());
-                            buf.push('\n');
-                        }
-
-                        write_indent(buf, indent + 4);
-                        if let Some(name) = variant.name() {
-                            buf.push_str(&name.text());
-                        }
-                        if let Some(field_list) = variant.field_list() {
-                            match field_list {
-                                ast::FieldList::RecordFieldList(record_fields) => {
-                                    buf.push_str(" {\n");
-                                    fields::format_record_fields(&record_fields, buf, indent + 8);
-                                    write_indent(buf, indent + 4);
-                                    buf.push('}');
-                                }
-                                ast::FieldList::TupleFieldList(fields_tuple) => {
-                                    buf.push('(');
-                                    for (i, field) in fields_tuple.fields().enumerate() {
-                                        if i > 0 {
-                                            buf.push_str(", ");
-                                        }
-                                        if let Some(vis) = field.visibility() {
-                                            buf.push_str(&vis.syntax().text().to_string());
-                                            buf.push(' ');
-                                        }
-                                        if let Some(ty) = field.ty() {
-                                            buf.push_str(&ty.syntax().text().to_string());
-                                        }
-                                    }
-                                    buf.push(')');
-                                }
+                    ast::FieldList::TupleFieldList(fields_tuple) => {
+                        buf.push('(');
+                        for (i, field) in fields_tuple.fields().enumerate() {
+                            if i > 0 {
+                                buf.push_str(", ");
+                            }
+                            if let Some(vis) = field.visibility() {
+                                buf.push_str(&vis.syntax().text().to_string());
+                                buf.push(' ');
+                            }
+                            if let Some(ty) = field.ty() {
+                                buf.push_str(&ty.syntax().text().to_string());
                             }
                         }
-                        buf.push_str(",\n");
-
-                        // Check for trailing comment on same line as variant
-                        if let Some(trailing) = comments::get_trailing_comment(&children, idx)
-                            && buf.ends_with(",\n")
-                        {
-                            buf.pop(); // remove \n
-                            buf.push(' ');
-                            buf.push_str(&trailing);
-                            buf.push('\n');
-                        }
+                        buf.push(')');
                     }
                 }
-                _ => {}
             }
+            buf.push_str(",\n");
+
+            first_variant = false;
         }
 
         write_indent(buf, indent);

--- a/chloro-core/src/tests/formatter.rs
+++ b/chloro-core/src/tests/formatter.rs
@@ -1,6 +1,8 @@
 use crate::format_source;
 
+mod comments;
 mod functions;
+mod impl_blocks;
 mod struct_literals;
 mod use_items;
 

--- a/chloro-core/src/tests/formatter/comments.rs
+++ b/chloro-core/src/tests/formatter/comments.rs
@@ -1,0 +1,80 @@
+// chloro-core/src/tests/formatter/comments.rs
+
+use super::*;
+use insta::assert_snapshot;
+
+#[test]
+fn preserve_fixme_comments() {
+    let input = r#"struct Foo {
+    // FIXME: This should be fixed
+    field: i32,
+}
+"#;
+    let output = format_source(input);
+    assert_snapshot!(output, @r#"
+    struct Foo {
+        // FIXME: This should be fixed
+        field: i32,
+    }
+    "#);
+}
+
+#[test]
+fn preserve_inline_comments_in_enum() {
+    let input = r#"enum Foo {
+    // FIXME: We should use this when appropriate.
+    Yes,
+    No,
+}
+"#;
+    let output = format_source(input);
+    println!("{}", output);
+    assert!(output.contains("// FIXME: We should use this when appropriate."));
+}
+
+#[test]
+fn preserve_comments_before_enum_variant() {
+    let input = r#"enum PointerCast {
+    /// Go from a fn-item type to a fn-pointer type.
+    ReifyFnPointer,
+    /// Go from a safe fn pointer to an unsafe fn pointer.
+    UnsafeFnPointer,
+}
+"#;
+    let output = format_source(input);
+    assert_snapshot!(output, @r#"
+    enum PointerCast {
+        /// Go from a fn-item type to a fn-pointer type.
+        ReifyFnPointer,
+        /// Go from a safe fn pointer to an unsafe fn pointer.
+        UnsafeFnPointer,
+    }
+    "#);
+}
+
+#[test]
+fn no_spurious_blank_line_after_comment() {
+    let input = r#"fn foo() {
+    // Comment from rustc:
+    // Even though coercion casts provide type hints, we check casts after fallback for
+    // backwards compatibility.
+    let x = 1;
+}
+"#;
+    let output = format_source(input);
+    // Should NOT have double newline after the comment block
+    assert!(!output.contains("// backwards compatibility.\n\n"));
+}
+
+#[test]
+fn preserve_allow_attribute_after_doc_comment() {
+    let input = r#"enum PointerCast {
+    /// Go from `*const [T; N]` to `*const T`
+    #[allow(dead_code)]
+    ArrayToPointer,
+}
+"#;
+    let output = format_source(input);
+    // The doc comment should come before the attribute
+    assert!(output.contains("/// Go from `*const [T; N]` to `*const T`\n    #[allow(dead_code)]"));
+}

--- a/chloro-core/src/tests/formatter/impl_blocks.rs
+++ b/chloro-core/src/tests/formatter/impl_blocks.rs
@@ -1,0 +1,30 @@
+use super::*;
+
+#[test]
+fn impl_methods_have_blank_lines() {
+    let input = r#"impl Foo {
+    pub fn method_a(&self) -> i32 {
+        1
+    }
+    pub fn method_b(&self) -> i32 {
+        2
+    }
+}
+"#;
+    let output = format_source(input);
+    // Methods should be separated by blank lines
+    assert!(output.contains("}\n\n    pub fn method_b"));
+}
+
+#[test]
+fn impl_preserves_comments_on_methods() {
+    let input = r#"impl Foo {
+    // This method is consumed by external tools. Don't remove, please.
+    pub fn expression_types(&self) -> impl Iterator<Item = i32> {
+        std::iter::empty()
+    }
+}
+"#;
+    let output = format_source(input);
+    assert!(output.contains("// This method is consumed by external tools"));
+}

--- a/chloro-core/tests/conformance/snapshots/conformance__roundtrip__parser_crate_roundtrip_diff.snap
+++ b/chloro-core/tests/conformance/snapshots/conformance__roundtrip__parser_crate_roundtrip_diff.snap
@@ -4316,16 +4316,6 @@ expression: cleaned_diff
  /// `Parser` produces a flat list of `Event`s.
  /// They are converted to a tree-structure in
  /// a separate pass, via `TreeBuilder`.
-         kind: SyntaxKind,
-         forward_parent: Option<u32>,
-     },
--
-     /// Complete the previous `Start` event
-     Finish,
--
-     /// Produce a single leaf-element.
-     /// `n_raw_tokens` is used to glue complex contextual tokens.
-     /// For example, lexer tokenizes `>>` as `>`, `>`, and
  
  impl Event {
      pub(crate) fn tombstone() -> Self {
@@ -5366,6 +5356,7 @@ expression: cleaned_diff
  enum Flavor {
 -    FnDef, // Includes trait fn params; omitted param idents are not supported
 +    FnDef,
++    // Includes trait fn params; omitted param idents are not supported
      FnPointer,
      Closure,
  }

--- a/chloro-core/tests/conformance/snapshots/parser_crate_chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/parser_crate_chloro.rs
@@ -4810,8 +4810,10 @@ pub(crate) enum Event {
         kind: SyntaxKind,
         forward_parent: Option<u32>,
     },
+
     /// Complete the previous `Start` event
     Finish,
+
     /// Produce a single leaf-element.
     /// `n_raw_tokens` is used to glue complex contextual tokens.
     /// For example, lexer tokenizes `>>` as `>`, `>`, and
@@ -7619,6 +7621,7 @@ pub(super) fn param_list_closure(p: &mut Parser<'_>) {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Flavor {
     FnDef,
+    // Includes trait fn params; omitted param idents are not supported
     FnPointer,
     Closure,
 }

--- a/chloro-core/tests/conformance/snapshots/ra/hir/src_lib.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/hir/src_lib.chloro.rs
@@ -295,6 +295,8 @@ pub enum ModuleDef {
     Module(Module),
     Function(Function),
     Adt(Adt),
+    // Can't be directly declared, but can be imported.
+    // FIXME: Rename to `EnumVariant`
     Variant(Variant),
     Const(Const),
     Static(Static),
@@ -3547,6 +3549,7 @@ pub enum GenericDef {
     Trait(Trait),
     TypeAlias(TypeAlias),
     Impl(Impl),
+    // consts can have type parameters from their parents (i.e. associated consts of traits)
     Const(Const),
     Static(Static),
 }

--- a/chloro-core/tests/conformance/snapshots/ra/hir/src_lib.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/hir/src_lib.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 227843 bytes
-Chloro size:   225685 bytes
+Chloro size:   225872 bytes
 Rustfmt size:  227843 bytes
 
 ✗ Outputs DIFFER
@@ -227,14 +227,6 @@ Rustfmt size:  227843 bytes
      },
  };
  
-     Module(Module),
-     Function(Function),
-     Adt(Adt),
--    // Can't be directly declared, but can be imported.
--    // FIXME: Rename to `EnumVariant`
-     Variant(Variant),
-     Const(Const),
-     Static(Static),
      BuiltinType(BuiltinType),
      Macro(Macro),
  }
@@ -369,10 +361,6 @@ Rustfmt size:  227843 bytes
      pub fn str() -> BuiltinType {
          BuiltinType { inner: hir_def::builtin_type::BuiltinType::Str }
      }
-     Trait(Trait),
-     TypeAlias(TypeAlias),
-     Impl(Impl),
--    // consts can have type parameters from their parents (i.e. associated consts of traits)
      Const(Const),
      Static(Static),
  }

--- a/chloro-core/tests/conformance/snapshots/ra/hir/src_source_analyzer.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/hir/src_source_analyzer.chloro.rs
@@ -80,6 +80,7 @@ pub(crate) enum BodyOrSig<'db> {
         source_map: Arc<BodySourceMap>,
         infer: Option<Arc<InferenceResult<'db>>>,
     },
+    // To be folded into body once it is considered one
     VariantFields {
         def: VariantId,
         store: Arc<ExpressionStore>,
@@ -89,7 +90,6 @@ pub(crate) enum BodyOrSig<'db> {
         def: GenericDefId,
         store: Arc<ExpressionStore>,
         source_map: Arc<ExpressionStoreSourceMap>,
-        // infer: Option<Arc<InferenceResult>>,
     },
 }
 

--- a/chloro-core/tests/conformance/snapshots/ra/hir/src_source_analyzer.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/hir/src_source_analyzer.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 72179 bytes
-Chloro size:   71966 bytes
+Chloro size:   71974 bytes
 Rustfmt size:  72179 bytes
 
 ✗ Outputs DIFFER
@@ -87,13 +87,13 @@ Rustfmt size:  72179 bytes
  };
  
  /// `SourceAnalyzer` is a convenience wrapper which exposes HIR API in terms of
-         source_map: Arc<BodySourceMap>,
-         infer: Option<Arc<InferenceResult<'db>>>,
-     },
--    // To be folded into body once it is considered one
-     VariantFields {
-         def: VariantId,
+         def: GenericDefId,
          store: Arc<ExpressionStore>,
+         source_map: Arc<ExpressionStoreSourceMap>,
+-        // infer: Option<Arc<InferenceResult>>,
+     },
+ }
+ 
          SourceAnalyzer { resolver, body_or_sig: None, file_id: node.file_id }
      }
  

--- a/chloro-core/tests/conformance/snapshots/ra/hir_def/src_expr_store.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_def/src_expr_store.chloro.rs
@@ -128,6 +128,8 @@ pub struct ExpressionStore {
 
 #[derive(Debug, Eq, Default)]
 struct ExpressionOnlySourceMap {
+    // AST expressions can create patterns in destructuring assignments. Therefore, `ExprSource` can also map
+    // to `PatId`, and `PatId` can also map to `ExprSource` (the other way around is unaffected).
     expr_map: FxHashMap<ExprSource, ExprOrPatId>,
     expr_map_back: ArenaMap<ExprId, ExprOrPatSource>,
     pat_map: FxHashMap<PatSource, ExprOrPatId>,
@@ -141,6 +143,9 @@ struct ExpressionOnlySourceMap {
     pat_field_map_back: FxHashMap<PatId, PatFieldSource>,
     template_map: Option<Box<FormatTemplate>>,
     expansions: FxHashMap<InFile<MacroCallPtr>, MacroCallId>,
+    //
+    // We store diagnostics on the `ExpressionOnlySourceMap` because diagnostics are rare (except
+    // maybe for cfgs, and they are also not common in type places).
     /// Diagnostics accumulated during lowering. These contain `AstPtr`s and so are stored in
     /// the source map (since they're just as volatile).
     diagnostics: ThinVec<ExpressionStoreDiagnostics>,
@@ -215,6 +220,8 @@ pub struct ExpressionStoreBuilder {
     pub types: Arena<TypeRef>,
     block_scopes: Vec<BlockId>,
     ident_hygiene: FxHashMap<ExprOrPatId, HygieneId>,
+    // AST expressions can create patterns in destructuring assignments. Therefore, `ExprSource` can also map
+    // to `PatId`, and `PatId` can also map to `ExprSource` (the other way around is unaffected).
     expr_map: FxHashMap<ExprSource, ExprOrPatId>,
     expr_map_back: ArenaMap<ExprId, ExprOrPatSource>,
     pat_map: FxHashMap<PatSource, ExprOrPatId>,
@@ -232,6 +239,9 @@ pub struct ExpressionStoreBuilder {
     pat_field_map_back: FxHashMap<PatId, PatFieldSource>,
     template_map: Option<Box<FormatTemplate>>,
     expansions: FxHashMap<InFile<MacroCallPtr>, MacroCallId>,
+    //
+    // We store diagnostics on the `ExpressionOnlySourceMap` because diagnostics are rare (except
+    // maybe for cfgs, and they are also not common in type places).
     /// Diagnostics accumulated during lowering. These contain `AstPtr`s and so are stored in
     /// the source map (since they're just as volatile).
     pub(crate) diagnostics: Vec<ExpressionStoreDiagnostics>,

--- a/chloro-core/tests/conformance/snapshots/ra/hir_def/src_expr_store.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_def/src_expr_store.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 35489 bytes
-Chloro size:   34409 bytes
+Chloro size:   35173 bytes
 Rustfmt size:  37277 bytes
 
 ✗ Outputs DIFFER
@@ -99,11 +99,7 @@ Rustfmt size:  37277 bytes
      /// A map from an variable usages to their hygiene ID.
      ///
      /// Expressions (and destructuing patterns) that can be recorded here are single segment path, although not all single segments path refer
- 
- #[derive(Debug, Eq, Default)]
- struct ExpressionOnlySourceMap {
--    // AST expressions can create patterns in destructuring assignments. Therefore, `ExprSource` can also map
--    // to `PatId`, and `PatId` can also map to `ExprSource` (the other way around is unaffected).
+     // to `PatId`, and `PatId` can also map to `ExprSource` (the other way around is unaffected).
      expr_map: FxHashMap<ExprSource, ExprOrPatId>,
      expr_map_back: ArenaMap<ExprId, ExprOrPatSource>,
 -
@@ -126,11 +122,13 @@ Rustfmt size:  37277 bytes
 -
      expansions: FxHashMap<InFile<MacroCallPtr>, MacroCallId>,
 -
-     /// Diagnostics accumulated during lowering. These contain `AstPtr`s and so are stored in
-     /// the source map (since they're just as volatile).
--    //
--    // We store diagnostics on the `ExpressionOnlySourceMap` because diagnostics are rare (except
--    // maybe for cfgs, and they are also not common in type places).
+-    /// Diagnostics accumulated during lowering. These contain `AstPtr`s and so are stored in
+-    /// the source map (since they're just as volatile).
+     //
+     // We store diagnostics on the `ExpressionOnlySourceMap` because diagnostics are rare (except
+     // maybe for cfgs, and they are also not common in type places).
++    /// Diagnostics accumulated during lowering. These contain `AstPtr`s and so are stored in
++    /// the source map (since they're just as volatile).
      diagnostics: ThinVec<ExpressionStoreDiagnostics>,
  }
  
@@ -163,8 +161,8 @@ Rustfmt size:  37277 bytes
      block_scopes: Vec<BlockId>,
      ident_hygiene: FxHashMap<ExprOrPatId, HygieneId>,
 -
--    // AST expressions can create patterns in destructuring assignments. Therefore, `ExprSource` can also map
--    // to `PatId`, and `PatId` can also map to `ExprSource` (the other way around is unaffected).
+     // AST expressions can create patterns in destructuring assignments. Therefore, `ExprSource` can also map
+     // to `PatId`, and `PatId` can also map to `ExprSource` (the other way around is unaffected).
      expr_map: FxHashMap<ExprSource, ExprOrPatId>,
      expr_map_back: ArenaMap<ExprId, ExprOrPatSource>,
 -
@@ -193,11 +191,13 @@ Rustfmt size:  37277 bytes
 -
      expansions: FxHashMap<InFile<MacroCallPtr>, MacroCallId>,
 -
-     /// Diagnostics accumulated during lowering. These contain `AstPtr`s and so are stored in
-     /// the source map (since they're just as volatile).
--    //
--    // We store diagnostics on the `ExpressionOnlySourceMap` because diagnostics are rare (except
--    // maybe for cfgs, and they are also not common in type places).
+-    /// Diagnostics accumulated during lowering. These contain `AstPtr`s and so are stored in
+-    /// the source map (since they're just as volatile).
+     //
+     // We store diagnostics on the `ExpressionOnlySourceMap` because diagnostics are rare (except
+     // maybe for cfgs, and they are also not common in type places).
++    /// Diagnostics accumulated during lowering. These contain `AstPtr`s and so are stored in
++    /// the source map (since they're just as volatile).
      pub(crate) diagnostics: Vec<ExpressionStoreDiagnostics>,
  }
  

--- a/chloro-core/tests/conformance/snapshots/ra/hir_def/src_expr_store_lower.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_def/src_expr_store_lower.chloro.rs
@@ -413,6 +413,8 @@ pub struct ExprCollector<'db> {
     local_def_map: &'db LocalDefMap,
     module: ModuleId,
     pub store: ExpressionStoreBuilder,
+    // state stuff
+    // Prevent nested impl traits like `impl Foo<impl Bar>`.
     outer_impl_trait: bool,
     is_lowering_coroutine: bool,
     /// Legacy (`macro_rules!`) macros can have multiple definitions and shadow each other,

--- a/chloro-core/tests/conformance/snapshots/ra/hir_def/src_expr_store_lower.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_def/src_expr_store_lower.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 144317 bytes
-Chloro size:   143706 bytes
+Chloro size:   143786 bytes
 Rustfmt size:  144317 bytes
 
 ✗ Outputs DIFFER
@@ -89,8 +89,8 @@ Rustfmt size:  144317 bytes
      module: ModuleId,
      pub store: ExpressionStoreBuilder,
 -
--    // state stuff
--    // Prevent nested impl traits like `impl Foo<impl Bar>`.
+     // state stuff
+     // Prevent nested impl traits like `impl Foo<impl Bar>`.
      outer_impl_trait: bool,
 -
      is_lowering_coroutine: bool,

--- a/chloro-core/tests/conformance/snapshots/ra/hir_def/src_expr_store_scope.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_def/src_expr_store_scope.chloro.rs
@@ -46,6 +46,7 @@ pub struct ScopeData {
     parent: Option<ScopeId>,
     block: Option<BlockId>,
     label: Option<(LabelId, Name)>,
+    // FIXME: We can compress this with an enum for this and `label`/`block` if memory usage matters.
     macro_def: Option<Box<MacroDefId>>,
     entries: IdxRange<ScopeEntry>,
 }

--- a/chloro-core/tests/conformance/snapshots/ra/hir_def/src_expr_store_scope.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_def/src_expr_store_scope.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 19259 bytes
-Chloro size:   19054 bytes
+Chloro size:   19156 bytes
 Rustfmt size:  19938 bytes
 
 ✗ Outputs DIFFER
@@ -15,13 +15,6 @@ Rustfmt size:  19938 bytes
  use la_arena::{Arena, ArenaMap, Idx, IdxRange, RawIdx};
  use triomphe::Arc;
  
-     parent: Option<ScopeId>,
-     block: Option<BlockId>,
-     label: Option<(LabelId, Name)>,
--    // FIXME: We can compress this with an enum for this and `label`/`block` if memory usage matters.
-     macro_def: Option<Box<MacroDefId>>,
-     entries: IdxRange<ScopeEntry>,
- }
      }
  
      /// If `scope` refers to a macro def scope, returns the corresponding `MacroId`.

--- a/chloro-core/tests/conformance/snapshots/ra/hir_def/src_hir.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_def/src_hir.chloro.rs
@@ -115,6 +115,9 @@ pub enum Literal {
     Bool(bool),
     Int(i128, Option<BuiltinInt>),
     Uint(u128, Option<BuiltinUint>),
+    // Here we are using a wrapper around float because float primitives do not implement Eq, so they
+    // could not be used directly here, to understand how the wrapper works go to definition of
+    // FloatTypeWrapper
     Float(FloatTypeWrapper, Option<BuiltinFloat>),
 }
 
@@ -199,6 +202,7 @@ pub enum Expr {
         tail: Option<ExprId>,
     },
     Const(ExprId),
+    // FIXME: Fold this into Block with an unsafe flag?
     Unsafe {
         id: Option<BlockId>,
         statements: Box<[Statement]>,
@@ -275,6 +279,7 @@ pub enum Expr {
         rhs: ExprId,
         op: Option<BinaryOp>,
     },
+    // Assignments need a special treatment because of destructuring assignment.
     Assignment {
         target: PatId,
         value: ExprId,
@@ -505,10 +510,13 @@ pub enum BindingAnnotation {
     /// mode `None`; if you do `let Some(x) = &Some(22)`, it will
     /// ultimately be inferred to be by-reference.
     Unannotated,
+
     /// Annotated with `mut x` -- could be either ref or not, similar to `None`.
     Mutable,
+
     /// Annotated as `ref`, like `ref x`
     Ref,
+
     /// Annotated as `ref mut x`.
     RefMut,
 }

--- a/chloro-core/tests/conformance/snapshots/ra/hir_def/src_hir.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_def/src_hir.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 17460 bytes
-Chloro size:   16238 bytes
+Chloro size:   16600 bytes
 Rustfmt size:  17756 bytes
 
 ✗ Outputs DIFFER
@@ -66,12 +66,6 @@ Rustfmt size:  17756 bytes
  impl FloatTypeWrapper {
      pub fn new(sym: Symbol) -> Self {
          Self(sym)
-     Bool(bool),
-     Int(i128, Option<BuiltinInt>),
-     Uint(u128, Option<BuiltinUint>),
--    // Here we are using a wrapper around float because float primitives do not implement Eq, so they
--    // could not be used directly here, to understand how the wrapper works go to definition of
--    // FloatTypeWrapper
      Float(FloatTypeWrapper, Option<BuiltinFloat>),
  }
  
@@ -114,20 +108,6 @@ Rustfmt size:  17756 bytes
                  Literal::String(text)
              }
              LiteralKind::CString(s) => {
-         tail: Option<ExprId>,
-     },
-     Const(ExprId),
--    // FIXME: Fold this into Block with an unsafe flag?
-     Unsafe {
-         id: Option<BlockId>,
-         statements: Box<[Statement]>,
-         rhs: ExprId,
-         op: Option<BinaryOp>,
-     },
--    // Assignments need a special treatment because of destructuring assignment.
-     Assignment {
-         target: PatId,
-         value: ExprId,
  
  #[derive(Clone, Copy, PartialEq, Eq, Hash)]
  pub struct AsmOptions(u16);
@@ -183,19 +163,6 @@ Rustfmt size:  17756 bytes
  }
  
  #[derive(Debug, Clone, Eq, PartialEq)]
-     /// mode `None`; if you do `let Some(x) = &Some(22)`, it will
-     /// ultimately be inferred to be by-reference.
-     Unannotated,
--
-     /// Annotated with `mut x` -- could be either ref or not, similar to `None`.
-     Mutable,
--
-     /// Annotated as `ref`, like `ref x`
-     Ref,
--
-     /// Annotated as `ref mut x`.
-     RefMut,
- }
                  args.iter().copied().for_each(f);
              }
              Pat::Ref { pat, .. } => f(*pat),

--- a/chloro-core/tests/conformance/snapshots/ra/hir_def/src_hir_type_ref.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_def/src_hir_type_ref.chloro.rs
@@ -132,6 +132,8 @@ pub enum TypeRef {
     Tuple(ThinVec<TypeRefId>),
     Path(Path),
     RawPtr(TypeRefId, Mutability),
+    // FIXME: Unbox this once `Idx` has a niche,
+    // as `RefType` should shrink by 4 bytes then
     Reference(Box<RefType>),
     Array(ArrayType),
     Slice(TypeRefId),
@@ -274,6 +276,11 @@ pub enum LiteralConstRef {
     UInt(u128),
     Bool(bool),
     Char(char),
+
+    // FIXME: this is a hack to get around chalk not being able to represent unevaluatable
+    // constants
+    // https://github.com/rust-lang/rust-analyzer/pull/8813#issuecomment-840679177
+    // https://rust-lang.zulipchat.com/#narrow/stream/144729-wg-traits/topic/Handling.20non.20evaluatable.20constants'.20equality/near/238386348
     /// Case of an unknown value that rustc might know but we don't
     Unknown,
 }

--- a/chloro-core/tests/conformance/snapshots/ra/hir_def/src_hir_type_ref.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_def/src_hir_type_ref.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 9897 bytes
-Chloro size:   9432 bytes
+Chloro size:   9868 bytes
 Rustfmt size:  10040 bytes
 
 ✗ Outputs DIFFER
@@ -64,14 +64,6 @@ Rustfmt size:  10040 bytes
          (params, ret.1)
      }
  }
-     Tuple(ThinVec<TypeRefId>),
-     Path(Path),
-     RawPtr(TypeRefId, Mutability),
--    // FIXME: Unbox this once `Idx` has a niche,
--    // as `RefType` should shrink by 4 bytes then
-     Reference(Box<RefType>),
-     Array(ArrayType),
-     Slice(TypeRefId),
  }
  
  #[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
@@ -101,15 +93,15 @@ Rustfmt size:  10040 bytes
                  TypeRef::Tuple(types) => types.iter().for_each(|&t| go(t, f, map)),
                  TypeRef::RawPtr(type_ref, _) | TypeRef::Slice(type_ref) => go(*type_ref, f, map),
                  TypeRef::Reference(it) => go(it.ty, f, map),
-     UInt(u128),
      Bool(bool),
      Char(char),
--
-     /// Case of an unknown value that rustc might know but we don't
--    // FIXME: this is a hack to get around chalk not being able to represent unevaluatable
--    // constants
--    // https://github.com/rust-lang/rust-analyzer/pull/8813#issuecomment-840679177
--    // https://rust-lang.zulipchat.com/#narrow/stream/144729-wg-traits/topic/Handling.20non.20evaluatable.20constants'.20equality/near/238386348
+ 
+-    /// Case of an unknown value that rustc might know but we don't
+     // FIXME: this is a hack to get around chalk not being able to represent unevaluatable
+     // constants
+     // https://github.com/rust-lang/rust-analyzer/pull/8813#issuecomment-840679177
+     // https://rust-lang.zulipchat.com/#narrow/stream/144729-wg-traits/topic/Handling.20non.20evaluatable.20constants'.20equality/near/238386348
++    /// Case of an unknown value that rustc might know but we don't
      Unknown,
  }
  

--- a/chloro-core/tests/conformance/snapshots/ra/hir_def/src_item_scope.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_def/src_item_scope.chloro.rs
@@ -163,11 +163,14 @@ pub struct ItemScope {
     unnamed_consts: ThinVec<ConstId>,
     /// Traits imported via `use Trait as _;`.
     unnamed_trait_imports: ThinVec<(TraitId, Item<()>)>,
+    // the resolutions of the imports of this scope
     use_imports_types: FxHashMap<ImportOrExternCrate, ImportOrDef>,
     use_imports_values: FxHashMap<ImportOrGlob, ImportOrDef>,
     use_imports_macros: FxHashMap<ImportOrExternCrate, ImportOrDef>,
     use_decls: ThinVec<UseId>,
     extern_crate_decls: ThinVec<ExternCrateId>,
+    // FIXME: Macro shadowing in one module is not properly handled. Non-item place macros will
+    // be all resolved to the last one defined if shadowing happens.
     /// Macros visible in current module in legacy textual scope
     ///
     /// For macros invoked by an unqualified identifier like `bar!()`, `legacy_macros` will be searched in first.

--- a/chloro-core/tests/conformance/snapshots/ra/hir_def/src_item_scope.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_def/src_item_scope.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 33374 bytes
-Chloro size:   32989 bytes
+Chloro size:   33206 bytes
 Rustfmt size:  33374 bytes
 
 ✗ Outputs DIFFER
@@ -46,14 +46,18 @@ Rustfmt size:  33374 bytes
      /// Traits imported via `use Trait as _;`.
      unnamed_trait_imports: ThinVec<(TraitId, Item<()>)>,
 -
--    // the resolutions of the imports of this scope
+     // the resolutions of the imports of this scope
      use_imports_types: FxHashMap<ImportOrExternCrate, ImportOrDef>,
      use_imports_values: FxHashMap<ImportOrGlob, ImportOrDef>,
      use_imports_macros: FxHashMap<ImportOrExternCrate, ImportOrDef>,
 -
      use_decls: ThinVec<UseId>,
      extern_crate_decls: ThinVec<ExternCrateId>,
++    // FIXME: Macro shadowing in one module is not properly handled. Non-item place macros will
++    // be all resolved to the last one defined if shadowing happens.
      /// Macros visible in current module in legacy textual scope
+     ///
+     /// For macros invoked by an unqualified identifier like `bar!()`, `legacy_macros` will be searched in first.
      /// Note that this automatically inherit macros defined textually before the definition of module itself.
      ///
      /// Module scoped macros will be inserted into `items` instead of here.

--- a/chloro-core/tests/conformance/snapshots/ra/hir_def/src_item_tree.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_def/src_item_tree.chloro.rs
@@ -459,6 +459,7 @@ pub enum UseTreeKind {
         path: Interned<ModPath>,
         alias: Option<ImportAlias>,
     },
+
     /// ```ignore
     /// use *;  // (invalid, but can occur in nested tree)
     /// use path::*;
@@ -466,6 +467,7 @@ pub enum UseTreeKind {
     Glob {
         path: Option<Interned<ModPath>>,
     },
+
     /// ```ignore
     /// use prefix::{self, Item, ...};
     /// ```

--- a/chloro-core/tests/conformance/snapshots/ra/hir_def/src_item_tree.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_def/src_item_tree.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 23100 bytes
-Chloro size:   22129 bytes
+Chloro size:   22131 bytes
 Rustfmt size:  23685 bytes
 
 ✗ Outputs DIFFER
@@ -195,22 +195,16 @@ Rustfmt size:  23685 bytes
      }
  }
  
-         path: Interned<ModPath>,
-         alias: Option<ImportAlias>,
-     },
--
-     /// ```ignore
      /// use *;  // (invalid, but can occur in nested tree)
      /// use path::*;
      /// ```
 -    Glob { path: Option<Interned<ModPath>> },
--
 +    Glob {
 +        path: Option<Interned<ModPath>>,
 +    },
+ 
      /// ```ignore
      /// use prefix::{self, Item, ...};
-     /// ```
  }
  
  #[derive(Debug, Clone, Eq, PartialEq)]

--- a/chloro-core/tests/conformance/snapshots/ra/hir_def/src_lib.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_def/src_lib.chloro.rs
@@ -131,6 +131,7 @@ impl<N: AstIdNode> HasModule for ItemLoc<N> {
 
 #[derive(Debug)]
 pub struct AssocItemLoc<N: AstIdNode> {
+    // FIXME: Store this as an erased `salsa::Id` to save space
     pub container: ItemContainerId,
     pub id: AstId<N>,
 }
@@ -557,6 +558,7 @@ pub type LocalModuleId = Idx<nameres::ModuleData>;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct FieldId {
+    // FIXME: Store this as an erased `salsa::Id` to save space
     pub parent: VariantId,
     pub local_id: LocalFieldId,
 }
@@ -572,6 +574,7 @@ pub struct TupleFieldId {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct TypeOrConstParamId {
+    // FIXME: Store this as an erased `salsa::Id` to save space
     pub parent: GenericDefId,
     pub local_id: LocalTypeOrConstParamId,
 }
@@ -632,6 +635,7 @@ impl From<ConstParamId> for TypeOrConstParamId {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct LifetimeParamId {
+    // FIXME: Store this as an erased `salsa::Id` to save space
     pub parent: GenericDefId,
     pub local_id: LocalLifetimeParamId,
 }
@@ -676,6 +680,7 @@ pub enum ModuleDefId {
     ModuleId(ModuleId),
     FunctionId(FunctionId),
     AdtId(AdtId),
+    // Can't be directly declared, but can be imported.
     EnumVariantId(EnumVariantId),
     ConstId(ConstId),
     StaticId(StaticId),
@@ -721,12 +726,6 @@ pub enum DefWithBodyId {
     StaticId(StaticId),
     ConstId(ConstId),
     VariantId(EnumVariantId),
-    // /// All fields of a variant are inference roots
-    // VariantId(VariantId),
-    // /// The signature can contain inference roots in a bunch of places
-    // /// like const parameters or const arguments in paths
-    // This should likely be kept on its own with a separate query
-    // GenericDefId(GenericDefId),
 }
 impl From<EnumVariantId> for DefWithBodyId {
     fn from(id: EnumVariantId) -> Self {
@@ -768,9 +767,13 @@ impl From<AssocItemId> for ModuleDefId {
 #[derive(Debug, PartialOrd, Ord, Clone, Copy, PartialEq, Eq, Hash, salsa_macros::Supertype)]
 pub enum GenericDefId {
     AdtId(AdtId),
+    // consts can have type parameters from their parents (i.e. associated consts of traits)
     ConstId(ConstId),
     FunctionId(FunctionId),
     ImplId(ImplId),
+    // can't actually have generics currently, but they might in the future
+    // More importantly, this completes the set of items that contain type references
+    // which is to be used by the signature expression store in the future.
     StaticId(StaticId),
     TraitId(TraitId),
     TypeAliasId(TypeAliasId),

--- a/chloro-core/tests/conformance/snapshots/ra/hir_def/src_lib.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_def/src_lib.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 44403 bytes
-Chloro size:   40661 bytes
+Chloro size:   40983 bytes
 Rustfmt size:  45085 bytes
 
 ✗ Outputs DIFFER
@@ -122,13 +122,6 @@ Rustfmt size:  45085 bytes
  
  impl<N: AstIdNode> Hash for ItemLoc<N> {
      fn hash<H: Hasher>(&self, state: &mut H) {
- 
- #[derive(Debug)]
- pub struct AssocItemLoc<N: AstIdNode> {
--    // FIXME: Store this as an erased `salsa::Id` to save space
-     pub container: ItemContainerId,
-     pub id: AstId<N>,
- }
      }
  }
  
@@ -401,20 +394,6 @@ Rustfmt size:  45085 bytes
      }
  
      /// Returns the module containing `self`, either the parent `mod`, or the module (or block) containing
- 
- #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
- pub struct FieldId {
--    // FIXME: Store this as an erased `salsa::Id` to save space
-     pub parent: VariantId,
-     pub local_id: LocalFieldId,
- }
- 
- #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
- pub struct TypeOrConstParamId {
--    // FIXME: Store this as an erased `salsa::Id` to save space
-     pub parent: GenericDefId,
-     pub local_id: LocalTypeOrConstParamId,
- }
      pub fn parent(&self) -> GenericDefId {
          self.0.parent
      }
@@ -429,13 +408,6 @@ Rustfmt size:  45085 bytes
      pub fn local_id(&self) -> LocalTypeOrConstParamId {
          self.0.local_id
      }
- 
- #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
- pub struct LifetimeParamId {
--    // FIXME: Store this as an erased `salsa::Id` to save space
-     pub parent: GenericDefId,
-     pub local_id: LocalLifetimeParamId,
- }
      ImplId(ImplId),
      TraitId(TraitId),
  }
@@ -468,13 +440,6 @@ Rustfmt size:  45085 bytes
  /// The defs which can be visible in the module.
  #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
  pub enum ModuleDefId {
-     ModuleId(ModuleId),
-     FunctionId(FunctionId),
-     AdtId(AdtId),
--    // Can't be directly declared, but can be imported.
-     EnumVariantId(EnumVariantId),
-     ConstId(ConstId),
-     StaticId(StaticId),
      BuiltinType(BuiltinType),
      MacroId(MacroId),
  }
@@ -518,8 +483,15 @@ Rustfmt size:  45085 bytes
              GeneralConstId::ConstId(const_id) => {
                  db.const_signature(const_id).name.as_ref().map_or_else(
                      || "_".to_owned(),
-     // This should likely be kept on its own with a separate query
-     // GenericDefId(GenericDefId),
+     StaticId(StaticId),
+     ConstId(ConstId),
+     VariantId(EnumVariantId),
+-    // /// All fields of a variant are inference roots
+-    // VariantId(VariantId),
+-    // /// The signature can contain inference roots in a bunch of places
+-    // /// like const parameters or const arguments in paths
+-    // This should likely be kept on its own with a separate query
+-    // GenericDefId(GenericDefId),
  }
 -impl_from!(FunctionId, ConstId, StaticId for DefWithBodyId);
 -
@@ -539,17 +511,6 @@ Rustfmt size:  45085 bytes
  impl From<AssocItemId> for ModuleDefId {
      fn from(item: AssocItemId) -> Self {
          match item {
- #[derive(Debug, PartialOrd, Ord, Clone, Copy, PartialEq, Eq, Hash, salsa_macros::Supertype)]
- pub enum GenericDefId {
-     AdtId(AdtId),
--    // consts can have type parameters from their parents (i.e. associated consts of traits)
-     ConstId(ConstId),
-     FunctionId(FunctionId),
-     ImplId(ImplId),
--    // can't actually have generics currently, but they might in the future
--    // More importantly, this completes the set of items that contain type references
--    // which is to be used by the signature expression store in the future.
-     StaticId(StaticId),
      TraitId(TraitId),
      TypeAliasId(TypeAliasId),
  }

--- a/chloro-core/tests/conformance/snapshots/ra/hir_def/src_nameres.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_def/src_nameres.chloro.rs
@@ -104,6 +104,8 @@ const PREDEFINED_TOOLS: &[SmolStr] = &[
 /// DefMap.
 #[derive(Debug, PartialEq, Eq, Default)]
 pub struct LocalDefMap {
+    // FIXME: There are probably some other things that could be here, but this is less severe and you
+    // need to be careful with things that block def maps also have.
     /// The extern prelude which contains all root modules of external crates that are in scope.
     extern_prelude: FxIndexMap<Name, (CrateRootModuleId, Option<ExternCrateId>)>,
 }
@@ -164,6 +166,7 @@ pub struct DefMap {
     /// this contains all kinds of macro, not just `macro_rules!` macro.
     /// ExternCrateId being None implies it being imported from the general prelude import.
     macro_use_prelude: FxHashMap<Name, (MacroId, Option<ExternCrateId>)>,
+    // FIXME: Figure out a better way for the IDE layer to resolve these?
     /// Tracks which custom derives are in scope for an item, to allow resolution of derive helper
     /// attributes.
     derive_helpers_in_scope: FxHashMap<AstId<ast::Item>, Vec<(Name, MacroId, MacroCallId)>>,

--- a/chloro-core/tests/conformance/snapshots/ra/hir_def/src_nameres.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_def/src_nameres.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 29602 bytes
-Chloro size:   29209 bytes
+Chloro size:   29455 bytes
 Rustfmt size:  30449 bytes
 
 ✗ Outputs DIFFER
@@ -30,14 +30,6 @@ Rustfmt size:  30449 bytes
  pub use self::path_resolution::ResolvePathResultPrefixInfo;
  
  const PREDEFINED_TOOLS: &[SmolStr] = &[
- /// DefMap.
- #[derive(Debug, PartialEq, Eq, Default)]
- pub struct LocalDefMap {
--    // FIXME: There are probably some other things that could be here, but this is less severe and you
--    // need to be careful with things that block def maps also have.
-     /// The extern prelude which contains all root modules of external crates that are in scope.
-     extern_prelude: FxIndexMap<Name, (CrateRootModuleId, Option<ExternCrateId>)>,
- }
  }
  
  impl LocalDefMap {
@@ -61,6 +53,7 @@ Rustfmt size:  30449 bytes
      /// ExternCrateId being None implies it being imported from the general prelude import.
      macro_use_prelude: FxHashMap<Name, (MacroId, Option<ExternCrateId>)>,
 -
++    // FIXME: Figure out a better way for the IDE layer to resolve these?
      /// Tracks which custom derives are in scope for an item, to allow resolution of derive helper
      /// attributes.
 -    // FIXME: Figure out a better way for the IDE layer to resolve these?

--- a/chloro-core/tests/conformance/snapshots/ra/hir_def/src_nameres_assoc.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_def/src_nameres_assoc.chloro.rs
@@ -33,6 +33,7 @@ use crate::{
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TraitItems {
     pub items: Box<[(Name, AssocItemId)]>,
+    // `ThinVec` as the vec is usually empty anyways
     pub macro_calls: ThinVec<(AstId<ast::Item>, MacroCallId)>,
 }
 
@@ -104,6 +105,7 @@ impl TraitItems {
 #[derive(Debug, PartialEq, Eq)]
 pub struct ImplItems {
     pub items: Box<[(Name, AssocItemId)]>,
+    // `ThinVec` as the vec is usually empty anyways
     pub macro_calls: ThinVec<(AstId<ast::Item>, MacroCallId)>,
 }
 

--- a/chloro-core/tests/conformance/snapshots/ra/hir_def/src_nameres_assoc.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_def/src_nameres_assoc.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 14069 bytes
-Chloro size:   13950 bytes
+Chloro size:   14056 bytes
 Rustfmt size:  14657 bytes
 
 ✗ Outputs DIFFER
@@ -19,13 +19,6 @@ Rustfmt size:  14657 bytes
      },
      AssocItemId, AstIdWithPath, ConstLoc, FunctionId, FunctionLoc, ImplId, ItemContainerId,
      ItemLoc, MacroCallId, ModuleId, TraitId, TypeAliasId, TypeAliasLoc,
- #[derive(Debug, Clone, PartialEq, Eq)]
- pub struct TraitItems {
-     pub items: Box<[(Name, AssocItemId)]>,
--    // `ThinVec` as the vec is usually empty anyways
-     pub macro_calls: ThinVec<(AstId<ast::Item>, MacroCallId)>,
- }
- 
          db: &dyn DefDatabase,
          tr: TraitId,
      ) -> (TraitItems, DefDiagnostics) {
@@ -78,13 +71,6 @@ Rustfmt size:  14657 bytes
      }
  
      pub fn macro_calls(&self) -> impl Iterator<Item = (AstId<ast::Item>, MacroCallId)> + '_ {
- #[derive(Debug, PartialEq, Eq)]
- pub struct ImplItems {
-     pub items: Box<[(Name, AssocItemId)]>,
--    // `ThinVec` as the vec is usually empty anyways
-     pub macro_calls: ThinVec<(AstId<ast::Item>, MacroCallId)>,
- }
- 
      #[salsa::tracked(returns(ref))]
      pub fn of(db: &dyn DefDatabase, id: ImplId) -> (ImplItems, DefDiagnostics) {
          let _p = tracing::info_span!("impl_items_with_diagnostics_query").entered();

--- a/chloro-core/tests/conformance/snapshots/ra/hir_def/src_nameres_collector.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_def/src_nameres_collector.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 108302 bytes
-Chloro size:   107569 bytes
+Chloro size:   107975 bytes
 Rustfmt size:  108302 bytes
 
 ✗ Outputs DIFFER
@@ -72,25 +72,18 @@ Rustfmt size:  108302 bytes
          attr: Attr,
          mod_item: ModItemId,
 -        /* is this needed? */ tree: TreeId,
++        /* is this needed? */
 +        tree: TreeId,
          item_tree: &'db ItemTree,
      },
  }
-     local_def_map: LocalDefMap,
-     /// Set only in case of blocks.
-     crate_local_def_map: Option<&'db LocalDefMap>,
--    // The dependencies of the current crate, including optional deps like `test`.
-     deps: FxIndexMap<Name, BuiltDependency>,
-     glob_imports: FxHashMap<LocalModuleId, Vec<(LocalModuleId, Visibility, GlobId)>>,
-     unresolved_imports: Vec<ImportDirective>,
-     indeterminate_imports: Vec<(ImportDirective, PerNs)>,
-     unresolved_macros: Vec<MacroDirective<'db>>,
--    // We'd like to avoid emitting a diagnostics avalanche when some `extern crate` doesn't
--    // resolve. When we emit diagnostics for unresolved imports, we only do so if the import
--    // doesn't start with an unresolved crate's name.
-     unresolved_extern_crates: FxHashSet<Name>,
-     mod_dirs: FxHashMap<LocalModuleId, ModDir>,
-     cfg_options: &'db CfgOptions,
+     proc_macros: Box<[(Name, CustomProcMacroExpander, bool)]>,
+     is_proc_macro: bool,
+     from_glob_import: PerNsGlobImports,
++    // FIXME: There has to be a better way to do this
+     /// If we fail to resolve an attribute on a `ModItem`, we fall back to ignoring the attribute.
+     /// This map is used to skip all attributes up to and including the one that failed to resolve,
+     /// in order to not expand them twice.
      ///
      /// This also stores the attributes to skip when we resolve derive helpers and non-macro
      /// non-builtin attributes in general.

--- a/chloro-core/tests/conformance/snapshots/ra/hir_def/src_resolver.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_def/src_resolver.chloro.rs
@@ -96,10 +96,13 @@ pub enum TypeNs {
     GenericParam(TypeParamId),
     AdtId(AdtId),
     AdtSelfType(AdtId),
+    // Yup, enum variants are added to the types ns, but any usage of variant as
+    // type is an error.
     EnumVariantId(EnumVariantId),
     TypeAliasId(TypeAliasId),
     BuiltinType(BuiltinType),
     TraitId(TraitId),
+
     ModuleId(ModuleId),
 }
 

--- a/chloro-core/tests/conformance/snapshots/ra/hir_def/src_resolver.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_def/src_resolver.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 54481 bytes
-Chloro size:   54332 bytes
+Chloro size:   54439 bytes
 Rustfmt size:  54481 bytes
 
 ✗ Outputs DIFFER
@@ -72,19 +72,6 @@ Rustfmt size:  54481 bytes
      /// Local bindings
      ExprScope(ExprScope),
      /// Macro definition inside bodies that affects all paths after it in the same block.
-     GenericParam(TypeParamId),
-     AdtId(AdtId),
-     AdtSelfType(AdtId),
--    // Yup, enum variants are added to the types ns, but any usage of variant as
--    // type is an error.
-     EnumVariantId(EnumVariantId),
-     TypeAliasId(TypeAliasId),
-     BuiltinType(BuiltinType),
-     TraitId(TraitId),
--
-     ModuleId(ModuleId),
- }
- 
          &self,
          db: &dyn DefDatabase,
          path: &Path,

--- a/chloro-core/tests/conformance/snapshots/ra/hir_def/src_signatures.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_def/src_signatures.chloro.rs
@@ -213,6 +213,7 @@ impl EnumSignature {
 #[derive(Debug, PartialEq, Eq)]
 pub struct ConstSignature {
     pub name: Option<Name>,
+    // generic_params: Arc<GenericParams>,
     pub store: Arc<ExpressionStore>,
     pub type_ref: TypeRefId,
     pub flags: ConstFlags,
@@ -254,6 +255,7 @@ impl ConstSignature {
 #[derive(Debug, PartialEq, Eq)]
 pub struct StaticSignature {
     pub name: Name,
+    // generic_params: Arc<GenericParams>,
     pub store: Arc<ExpressionStore>,
     pub type_ref: TypeRefId,
     pub flags: StaticFlags,
@@ -432,6 +434,7 @@ pub struct FunctionSignature {
     pub ret_type: Option<TypeRefId>,
     pub abi: Option<Symbol>,
     pub flags: FnFlags,
+    // FIXME: we should put this behind a fn flags + query to avoid bloating the struct
     pub legacy_const_generics_indices: Option<Box<Box<[u32]>>>,
 }
 

--- a/chloro-core/tests/conformance/snapshots/ra/hir_def/src_signatures.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_def/src_signatures.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 33467 bytes
-Chloro size:   30420 bytes
+Chloro size:   30594 bytes
 Rustfmt size:  34530 bytes
 
 ✗ Outputs DIFFER
@@ -157,10 +157,6 @@ Rustfmt size:  34530 bytes
  #[derive(Debug, PartialEq, Eq)]
  pub struct ConstSignature {
      pub name: Option<Name>,
--    // generic_params: Arc<GenericParams>,
-     pub store: Arc<ExpressionStore>,
-     pub type_ref: TypeRefId,
-     pub flags: ConstFlags,
          self.flags.contains(ConstFlags::HAS_BODY)
      }
  }
@@ -181,7 +177,7 @@ Rustfmt size:  34530 bytes
  pub struct StaticSignature {
      pub name: Name,
 -
--    // generic_params: Arc<GenericParams>,
+     // generic_params: Arc<GenericParams>,
      pub store: Arc<ExpressionStore>,
      pub type_ref: TypeRefId,
      pub flags: StaticFlags,
@@ -306,13 +302,6 @@ Rustfmt size:  34530 bytes
  #[derive(Debug, PartialEq, Eq)]
  pub struct FunctionSignature {
      pub name: Name,
-     pub ret_type: Option<TypeRefId>,
-     pub abi: Option<Symbol>,
-     pub flags: FnFlags,
--    // FIXME: we should put this behind a fn flags + query to avoid bloating the struct
-     pub legacy_const_generics_indices: Option<Box<Box<[u32]>>>,
- }
- 
  
          let name = as_name_opt(source.value.name());
          let abi = source.value.abi().map(|abi| {

--- a/chloro-core/tests/conformance/snapshots/ra/hir_expand/src_attrs.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_expand/src_attrs.chloro.rs
@@ -26,6 +26,7 @@ use crate::{
 /// Syntactical attributes, without filtering of `cfg_attr`s.
 #[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct RawAttrs {
+    // FIXME: This can become `Box<[Attr]>` if https://internals.rust-lang.org/t/layout-of-dst-box/21728?u=chrefr is accepted.
     entries: Option<ThinArc<(), Attr>>,
 }
 

--- a/chloro-core/tests/conformance/snapshots/ra/hir_expand/src_attrs.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_expand/src_attrs.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 16886 bytes
-Chloro size:   16521 bytes
+Chloro size:   16648 bytes
 Rustfmt size:  17571 bytes
 
 ✗ Outputs DIFFER
@@ -31,13 +31,6 @@ Rustfmt size:  17571 bytes
  use triomphe::ThinArc;
  
  use crate::{
- /// Syntactical attributes, without filtering of `cfg_attr`s.
- #[derive(Default, Debug, Clone, PartialEq, Eq)]
- pub struct RawAttrs {
--    // FIXME: This can become `Box<[Attr]>` if https://internals.rust-lang.org/t/layout-of-dst-box/21728?u=chrefr is accepted.
-     entries: Option<ThinArc<(), Attr>>,
- }
- 
          span_map: SpanMapRef<'_>,
      ) -> impl Iterator<Item = Attr> {
          collect_attrs(owner).filter_map(move |(id, attr)| match attr {

--- a/chloro-core/tests/conformance/snapshots/ra/hir_expand/src_cfg_process.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_expand/src_cfg_process.chloro.rs
@@ -84,6 +84,8 @@ enum CfgExprStage {
     StrippigCfgExpr,
     /// Found the comma after the CFGExpr. Will keep all tokens until the next comma or the end of the attribute
     FoundComma,
+    // FIXME: cfg_attr with multiple attributes will not be handled correctly. We will only keep the first attribute
+    // Related Issue: https://github.com/rust-lang/rust-analyzer/issues/10110
     /// Everything following the attribute. This could be another attribute or the end of the attribute.
     EverythingElse,
 }

--- a/chloro-core/tests/conformance/snapshots/ra/hir_expand/src_cfg_process.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_expand/src_cfg_process.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 14552 bytes
-Chloro size:   14361 bytes
+Chloro size:   14556 bytes
 Rustfmt size:  14552 bytes
 
 ✗ Outputs DIFFER
@@ -22,11 +22,13 @@ Rustfmt size:  14552 bytes
  };
  use tracing::{debug, warn};
  
+     StrippigCfgExpr,
      /// Found the comma after the CFGExpr. Will keep all tokens until the next comma or the end of the attribute
      FoundComma,
-     /// Everything following the attribute. This could be another attribute or the end of the attribute.
--    // FIXME: cfg_attr with multiple attributes will not be handled correctly. We will only keep the first attribute
--    // Related Issue: https://github.com/rust-lang/rust-analyzer/issues/10110
+-    /// Everything following the attribute. This could be another attribute or the end of the attribute.
+     // FIXME: cfg_attr with multiple attributes will not be handled correctly. We will only keep the first attribute
+     // Related Issue: https://github.com/rust-lang/rust-analyzer/issues/10110
++    /// Everything following the attribute. This could be another attribute or the end of the attribute.
      EverythingElse,
  }
  

--- a/chloro-core/tests/conformance/snapshots/ra/hir_expand/src_fixup.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_expand/src_fixup.chloro.rs
@@ -34,6 +34,7 @@ pub(crate) struct SyntaxFixups {
 /// This is the information needed to reverse the fixups.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct SyntaxFixupUndoInfo {
+    // FIXME: ThinArc<[Subtree]>
     original: Option<Arc<Box<[TopSubtree]>>>,
 }
 

--- a/chloro-core/tests/conformance/snapshots/ra/hir_expand/src_fixup.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_expand/src_fixup.diff
@@ -2,19 +2,12 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 28147 bytes
-Chloro size:   27627 bytes
+Chloro size:   27660 bytes
 Rustfmt size:  28368 bytes
 
 ✗ Outputs DIFFER
 
 === DIFF (- rustfmt, + chloro) ===
- /// This is the information needed to reverse the fixups.
- #[derive(Clone, Debug, Default, PartialEq, Eq)]
- pub struct SyntaxFixupUndoInfo {
--    // FIXME: ThinArc<[Subtree]>
-     original: Option<Arc<Box<[TopSubtree]>>>,
- }
- 
      pub(crate) const NONE: Self = SyntaxFixupUndoInfo { original: None };
  }
  

--- a/chloro-core/tests/conformance/snapshots/ra/hir_expand/src_lib.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_expand/src_lib.chloro.rs
@@ -303,6 +303,8 @@ pub enum MacroCallKind {
     FnLike {
         ast_id: AstId<ast::MacroCall>,
         expand_to: ExpandTo,
+        // FIXME: This is being interned, subtrees can vary quickly differing just slightly causing
+        // leakage problems here
         /// Some if this is a macro call for an eager macro. Note that this is `None`
         /// for the eager input macro file.
         eager: Option<Arc<EagerCallInfo>>,
@@ -322,6 +324,8 @@ pub enum MacroCallKind {
     },
     Attr {
         ast_id: AstId<ast::Item>,
+        // FIXME: This shouldn't be here, we can derive this from `invoc_attr_index`
+        // but we need to fix the `cfg_attr` handling first.
         attr_args: Option<Arc<tt::TopSubtree>>,
         /// Syntactical index of the invoking `#[attribute]`.
         ///

--- a/chloro-core/tests/conformance/snapshots/ra/hir_expand/src_lib.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_expand/src_lib.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 40650 bytes
-Chloro size:   39764 bytes
+Chloro size:   40043 bytes
 Rustfmt size:  40650 bytes
 
 ✗ Outputs DIFFER
@@ -148,22 +148,18 @@ Rustfmt size:  40650 bytes
  #[derive(Debug, Clone, PartialEq, Eq, Hash)]
  pub struct MacroCallLoc {
      pub def: MacroDefId,
+     FnLike {
+         ast_id: AstId<ast::MacroCall>,
          expand_to: ExpandTo,
-         /// Some if this is a macro call for an eager macro. Note that this is `None`
-         /// for the eager input macro file.
--        // FIXME: This is being interned, subtrees can vary quickly differing just slightly causing
--        // leakage problems here
+-        /// Some if this is a macro call for an eager macro. Note that this is `None`
+-        /// for the eager input macro file.
+         // FIXME: This is being interned, subtrees can vary quickly differing just slightly causing
+         // leakage problems here
++        /// Some if this is a macro call for an eager macro. Note that this is `None`
++        /// for the eager input macro file.
          eager: Option<Arc<EagerCallInfo>>,
      },
      Derive {
-     },
-     Attr {
-         ast_id: AstId<ast::Item>,
--        // FIXME: This shouldn't be here, we can derive this from `invoc_attr_index`
--        // but we need to fix the `cfg_attr` handling first.
-         attr_args: Option<Arc<tt::TopSubtree>>,
-         /// Syntactical index of the invoking `#[attribute]`.
-         ///
              HirFileId::MacroFile(m) => db.lookup_intern_macro_call(m).def.edition,
          }
      }

--- a/chloro-core/tests/conformance/snapshots/ra/hir_expand/src_mod_path.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_expand/src_mod_path.chloro.rs
@@ -35,6 +35,7 @@ pub enum PathKind {
     Crate,
     /// Absolute path (::foo)
     Abs,
+    // FIXME: Can we remove this somehow?
     /// `$crate` from macro expansion
     DollarCrate(Crate),
 }

--- a/chloro-core/tests/conformance/snapshots/ra/hir_expand/src_mod_path.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_expand/src_mod_path.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 13520 bytes
-Chloro size:   13480 bytes
+Chloro size:   13522 bytes
 Rustfmt size:  13520 bytes
 
 ✗ Outputs DIFFER
@@ -34,13 +34,6 @@ Rustfmt size:  13520 bytes
  
  #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
  pub struct ModPath {
-     Crate,
-     /// Absolute path (::foo)
-     Abs,
--    // FIXME: Can we remove this somehow?
-     /// `$crate` from macro expansion
-     DollarCrate(Crate),
- }
              _ => None,
          }
      }

--- a/chloro-core/tests/conformance/snapshots/ra/hir_expand/src_name.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_expand/src_name.chloro.rs
@@ -18,6 +18,8 @@ use syntax::{ast, format_smolstr};
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct Name {
     symbol: Symbol,
+    // If you are making this carry actual hygiene, beware that the special handling for variables and labels
+    // in bodies can go.
     ctx: (),
 }
 

--- a/chloro-core/tests/conformance/snapshots/ra/hir_expand/src_name.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_expand/src_name.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 8537 bytes
-Chloro size:   8193 bytes
+Chloro size:   8328 bytes
 Rustfmt size:  8636 bytes
 
 ✗ Outputs DIFFER
@@ -17,14 +17,6 @@ Rustfmt size:  8636 bytes
  use span::{Edition, SyntaxContext};
  use syntax::utils::is_raw_identifier;
  use syntax::{ast, format_smolstr};
- #[derive(Clone, PartialEq, Eq, Hash)]
- pub struct Name {
-     symbol: Symbol,
--    // If you are making this carry actual hygiene, beware that the special handling for variables and labels
--    // in bodies can go.
-     ctx: (),
- }
- 
      }
  }
  

--- a/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_autoderef.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_autoderef.chloro.rs
@@ -113,9 +113,12 @@ struct AutoderefTraits {
 /// Although called `Autoderef` it can be configured to use the
 /// `Receiver` trait instead of the `Deref` trait.
 pub(crate) struct Autoderef<'a, 'db, Steps = Vec<(Ty<'db>, AutoderefKind)>> {
+    // Meta infos:
     pub(crate) table: &'a mut InferenceTable<'db>,
     traits: Option<AutoderefTraits>,
+    // Current state:
     state: AutoderefSnapshot<'db, Steps>,
+    // Configurations:
     include_raw_pointers: bool,
     use_receiver_trait: bool,
 }

--- a/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_autoderef.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_autoderef.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 12941 bytes
-Chloro size:   12853 bytes
+Chloro size:   12917 bytes
 Rustfmt size:  13256 bytes
 
 ✗ Outputs DIFFER
@@ -56,20 +56,16 @@ Rustfmt size:  13256 bytes
      fn push(&mut self, ty: Ty<'db>, kind: AutoderefKind) {
          self.push((ty, kind));
      }
- /// Although called `Autoderef` it can be configured to use the
- /// `Receiver` trait instead of the `Deref` trait.
- pub(crate) struct Autoderef<'a, 'db, Steps = Vec<(Ty<'db>, AutoderefKind)>> {
--    // Meta infos:
+     // Meta infos:
      pub(crate) table: &'a mut InferenceTable<'db>,
      traits: Option<AutoderefTraits>,
 -
--    // Current state:
+     // Current state:
      state: AutoderefSnapshot<'db, Steps>,
 -
--    // Configurations:
+     // Configurations:
      include_raw_pointers: bool,
      use_receiver_trait: bool,
- }
      type Item = (Ty<'db>, usize);
  
      fn next(&mut self) -> Option<Self::Item> {

--- a/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_diagnostics_match_check.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_diagnostics_match_check.chloro.rs
@@ -54,11 +54,13 @@ pub(crate) struct Pat<'db> {
 pub(crate) enum PatKind<'db> {
     Wild,
     Never,
+
     /// `x`, `ref x`, `x @ P`, etc.
     Binding {
         name: Name,
         subpattern: Option<Pat<'db>>,
     },
+
     /// `Foo(...)` or `Foo{...}` or `Foo`, where `Foo` is a variant name from an ADT with
     /// multiple variants.
     Variant {
@@ -66,18 +68,23 @@ pub(crate) enum PatKind<'db> {
         enum_variant: EnumVariantId,
         subpatterns: Vec<FieldPat<'db>>,
     },
+
     /// `(...)`, `Foo(...)`, `Foo{...}`, or `Foo`, where `Foo` is a variant name from an ADT with
     /// a single variant.
     Leaf {
         subpatterns: Vec<FieldPat<'db>>,
     },
+
     /// `&P`, `&mut P`, etc.
     Deref {
         subpattern: Pat<'db>,
     },
+
+    // FIXME: for now, only bool literals are implemented
     LiteralBool {
         value: bool,
     },
+
     /// An or-pattern, e.g. `p | q`.
     /// Invariant: `pats.len() >= 2`.
     Or {

--- a/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_diagnostics_match_check.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_diagnostics_match_check.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 15979 bytes
-Chloro size:   15838 bytes
+Chloro size:   15902 bytes
 Rustfmt size:  15979 bytes
 
 ✗ Outputs DIFFER
@@ -38,42 +38,6 @@ Rustfmt size:  15979 bytes
  use self::pat_util::EnumerateAndAdjustIterator;
  
  #[derive(Clone, Debug)]
- pub(crate) enum PatKind<'db> {
-     Wild,
-     Never,
--
-     /// `x`, `ref x`, `x @ P`, etc.
-     Binding {
-         name: Name,
-         subpattern: Option<Pat<'db>>,
-     },
--
-     /// `Foo(...)` or `Foo{...}` or `Foo`, where `Foo` is a variant name from an ADT with
-     /// multiple variants.
-     Variant {
-         enum_variant: EnumVariantId,
-         subpatterns: Vec<FieldPat<'db>>,
-     },
--
-     /// `(...)`, `Foo(...)`, `Foo{...}`, or `Foo`, where `Foo` is a variant name from an ADT with
-     /// a single variant.
-     Leaf {
-         subpatterns: Vec<FieldPat<'db>>,
-     },
--
-     /// `&P`, `&mut P`, etc.
-     Deref {
-         subpattern: Pat<'db>,
-     },
--
--    // FIXME: for now, only bool literals are implemented
-     LiteralBool {
-         value: bool,
-     },
--
-     /// An or-pattern, e.g. `p | q`.
-     /// Invariant: `pats.len() >= 2`.
-     Or {
      }
  }
  

--- a/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_diagnostics_unsafe_check.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_diagnostics_unsafe_check.chloro.rs
@@ -148,6 +148,7 @@ struct UnsafeVisitor<'db> {
     inside_union_destructure: bool,
     callback: &'db mut dyn FnMut(UnsafeDiagnostic),
     def_target_features: TargetFeatures,
+    // FIXME: This needs to be the edition of the span of each call.
     edition: Edition,
     /// On some targets (WASM), calling safe functions with `#[target_feature]` is always safe, even when
     /// the target feature is not enabled. This flag encodes that.

--- a/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_diagnostics_unsafe_check.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_diagnostics_unsafe_check.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 17194 bytes
-Chloro size:   17146 bytes
+Chloro size:   17215 bytes
 Rustfmt size:  17194 bytes
 
 ✗ Outputs DIFFER
@@ -45,10 +45,3 @@ Rustfmt size:  17194 bytes
  }
  
  pub fn unsafe_operations_for_body<'db>(
-     inside_union_destructure: bool,
-     callback: &'db mut dyn FnMut(UnsafeDiagnostic),
-     def_target_features: TargetFeatures,
--    // FIXME: This needs to be the edition of the span of each call.
-     edition: Edition,
-     /// On some targets (WASM), calling safe functions with `#[target_feature]` is always safe, even when
-     /// the target feature is not enabled. This flag encodes that.

--- a/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_display.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_display.chloro.rs
@@ -115,6 +115,7 @@ pub enum DisplayLifetime {
 #[derive(Default)]
 enum BoundsFormattingCtx<'db> {
     Entered {
+        //. prevent recursing into their bounds to avoid infinite loops.
         /// We can have recursive bounds like the following case:
         /// ```ignore
         /// where

--- a/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_display.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_display.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 99713 bytes
-Chloro size:   99240 bytes
+Chloro size:   99313 bytes
 Rustfmt size:  99713 bytes
 
 ✗ Outputs DIFFER
@@ -104,6 +104,13 @@ Rustfmt size:  99713 bytes
  #[derive(Copy, Clone)]
  pub enum DisplayLifetime {
      Always,
+ #[derive(Default)]
+ enum BoundsFormattingCtx<'db> {
+     Entered {
++        //. prevent recursing into their bounds to avoid infinite loops.
+         /// We can have recursive bounds like the following case:
+         /// ```ignore
+         /// where
          ///     T::FooAssoc: Baz<<T::FooAssoc as Bar>::BarAssoc> + Bar
          /// ```
          /// So, record the projection types met while formatting bounds and

--- a/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_drop.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_drop.chloro.rs
@@ -37,6 +37,7 @@ fn has_destructor(db: &dyn HirDatabase, adt: AdtId) -> bool {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum DropGlue {
+    // Order of variants is important.
     None,
     /// May have a drop glue if some type parameter has it.
     ///

--- a/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_drop.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_drop.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 6718 bytes
-Chloro size:   6667 bytes
+Chloro size:   6706 bytes
 Rustfmt size:  6767 bytes
 
 ✗ Outputs DIFFER
@@ -36,11 +36,6 @@ Rustfmt size:  6767 bytes
  }
  
  #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
- pub enum DropGlue {
--    // Order of variants is important.
-     None,
-     /// May have a drop glue if some type parameter has it.
-     ///
      visited: &mut FxHashSet<Ty<'db>>,
  ) -> DropGlue {
      let mut ocx = ObligationCtxt::new(infcx);

--- a/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_dyn_compatibility.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_dyn_compatibility.chloro.rs
@@ -38,6 +38,7 @@ pub enum DynCompatibilityViolation {
     Method(FunctionId, MethodViolationCode),
     AssocConst(ConstId),
     GAT(TypeAliasId),
+    // This doesn't exist in rustc, but added for better visualization
     HasNonCompatibleSuperTrait(TraitId),
 }
 

--- a/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_dyn_compatibility.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_dyn_compatibility.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 18694 bytes
-Chloro size:   18377 bytes
+Chloro size:   18448 bytes
 Rustfmt size:  18694 bytes
 
 ✗ Outputs DIFFER
@@ -49,13 +49,6 @@ Rustfmt size:  18694 bytes
  };
  
  #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-     Method(FunctionId, MethodViolationCode),
-     AssocConst(ConstId),
-     GAT(TypeAliasId),
--    // This doesn't exist in rustc, but added for better visualization
-     HasNonCompatibleSuperTrait(TraitId),
- }
- 
      }
  
      // rustc checks for non-lifetime binders here, but we don't support HRTB yet

--- a/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_infer.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_infer.chloro.rs
@@ -221,6 +221,7 @@ pub enum InferenceDiagnostic<'db> {
     UnresolvedIdent {
         id: ExprOrPatId,
     },
+    // FIXME: This should be emitted in body lowering
     BreakOutsideOfLoop {
         expr: ExprId,
         is_break: bool,
@@ -356,6 +357,7 @@ impl<'db> Adjustment<'db> {
 /// See #49434 for tracking.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub(crate) enum AllowTwoPhase {
+    // FIXME: We should use this when appropriate.
     Yes,
     No,
 }
@@ -397,16 +399,21 @@ impl<'db> AutoBorrow<'db> {
 pub enum PointerCast {
     /// Go from a fn-item type to a fn-pointer type.
     ReifyFnPointer,
+
     /// Go from a safe fn pointer to an unsafe fn pointer.
     UnsafeFnPointer,
+
     /// Go from a non-capturing closure to an fn pointer or an unsafe fn pointer.
     /// It cannot convert a closure that requires unsafe.
     ClosureFnPointer(Safety),
+
     /// Go from a mut raw pointer to a const raw pointer.
     MutToConstPointer,
+
     /// Go from `*const [T; N]` to `*const T`
     #[allow(dead_code)]
     ArrayToPointer,
+
     /// Unsize a pointer/reference value, e.g., `&[T; n]` to
     /// `&[T]`. Note that the source could be a thin or fat pointer.
     /// This will do things like convert thin pointers to fat
@@ -450,8 +457,12 @@ pub struct InferenceResult<'db> {
     pub(crate) type_of_binding: ArenaMap<BindingId, Ty<'db>>,
     pub(crate) type_of_opaque: FxHashMap<InternedOpaqueTyId, Ty<'db>>,
     type_mismatches: FxHashMap<ExprOrPatId, TypeMismatch<'db>>,
+    // FIXME: This isn't as useful as initially thought due to us falling back placeholders to
+    // `TyKind::Error`.
+    // Which will then mark this field.
     /// Whether there are any type-mismatching errors in the result.
     pub(crate) has_errors: bool,
+    // FIXME: Remove this.
     /// Interned `Error` type to return references to.
     error_ty: Ty<'db>,
     /// Stores the types which were implicitly dereferenced in pattern binding modes.
@@ -472,6 +483,7 @@ pub struct InferenceResult<'db> {
     pub(crate) binding_modes: ArenaMap<PatId, BindingMode>,
     pub(crate) expr_adjustments: FxHashMap<ExprId, Box<[Adjustment<'db>]>>,
     pub(crate) closure_info: FxHashMap<InternedClosureId, (Vec<CapturedItem<'db>>, FnTrait)>,
+    // FIXME: remove this field
     pub mutated_bindings_in_closure: FxHashSet<BindingId>,
     pub(crate) coercion_casts: FxHashSet<ExprId>,
 }
@@ -790,6 +802,7 @@ pub(crate) struct InferenceContext<'body, 'db> {
     /// Whether we are inside the pattern of a destructuring assignment.
     inside_assignment: bool,
     deferred_cast_checks: Vec<CastCheck<'db>>,
+    // fields related to closure capture
     current_captures: Vec<CapturedItemWithoutTy<'db>>,
     /// A stack that has an entry for each projection in the current capture.
     ///

--- a/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_infer.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_infer.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 74236 bytes
-Chloro size:   72771 bytes
+Chloro size:   73140 bytes
 Rustfmt size:  74236 bytes
 
 ✗ Outputs DIFFER
@@ -90,13 +90,6 @@ Rustfmt size:  74236 bytes
      // backwards compatibility. This makes fallback a stronger type hint than a cast coercion.
      let cast_checks = std::mem::take(&mut ctx.deferred_cast_checks);
      for mut cast in cast_checks.into_iter() {
-     UnresolvedIdent {
-         id: ExprOrPatId,
-     },
--    // FIXME: This should be emitted in body lowering
-     BreakOutsideOfLoop {
-         expr: ExprId,
-         is_break: bool,
  impl<'db> Adjustment<'db> {
      pub fn borrow(interner: DbInterner<'db>, m: Mutability, ty: Ty<'db>, lt: Region<'db>) -> Self {
          let ty = Ty::new_ref(interner, lt, ty, m);
@@ -108,54 +101,30 @@ Rustfmt size:  74236 bytes
      }
  }
  
- /// See #49434 for tracking.
- #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
- pub(crate) enum AllowTwoPhase {
--    // FIXME: We should use this when appropriate.
-     Yes,
-     No,
- }
- pub enum PointerCast {
-     /// Go from a fn-item type to a fn-pointer type.
-     ReifyFnPointer,
--
-     /// Go from a safe fn pointer to an unsafe fn pointer.
-     UnsafeFnPointer,
--
-     /// Go from a non-capturing closure to an fn pointer or an unsafe fn pointer.
-     /// It cannot convert a closure that requires unsafe.
-     ClosureFnPointer(Safety),
--
      /// Go from a mut raw pointer to a const raw pointer.
      MutToConstPointer,
--
+ 
 -    #[allow(dead_code)]
      /// Go from `*const [T; N]` to `*const T`
 +    #[allow(dead_code)]
      ArrayToPointer,
--
+ 
      /// Unsize a pointer/reference value, e.g., `&[T; n]` to
-     /// `&[T]`. Note that the source could be a thin or fat pointer.
-     /// This will do things like convert thin pointers to fat
+     pub(crate) type_of_binding: ArenaMap<BindingId, Ty<'db>>,
      pub(crate) type_of_opaque: FxHashMap<InternedOpaqueTyId, Ty<'db>>,
      type_mismatches: FxHashMap<ExprOrPatId, TypeMismatch<'db>>,
-     /// Whether there are any type-mismatching errors in the result.
--    // FIXME: This isn't as useful as initially thought due to us falling back placeholders to
--    // `TyKind::Error`.
--    // Which will then mark this field.
+-    /// Whether there are any type-mismatching errors in the result.
+     // FIXME: This isn't as useful as initially thought due to us falling back placeholders to
+     // `TyKind::Error`.
+     // Which will then mark this field.
++    /// Whether there are any type-mismatching errors in the result.
      pub(crate) has_errors: bool,
-     /// Interned `Error` type to return references to.
--    // FIXME: Remove this.
+-    /// Interned `Error` type to return references to.
+     // FIXME: Remove this.
++    /// Interned `Error` type to return references to.
      error_ty: Ty<'db>,
      /// Stores the types which were implicitly dereferenced in pattern binding modes.
      pub(crate) pat_adjustments: FxHashMap<PatId, Vec<Ty<'db>>>,
-     pub(crate) binding_modes: ArenaMap<PatId, BindingMode>,
-     pub(crate) expr_adjustments: FxHashMap<ExprId, Box<[Adjustment<'db>]>>,
-     pub(crate) closure_info: FxHashMap<InternedClosureId, (Vec<CapturedItem<'db>>, FnTrait)>,
--    // FIXME: remove this field
-     pub mutated_bindings_in_closure: FxHashSet<BindingId>,
-     pub(crate) coercion_casts: FxHashSet<ExprId>,
- }
      pub fn method_resolution(&self, expr: ExprId) -> Option<(FunctionId, GenericArgs<'db>)> {
          self.method_resolutions.get(&expr).copied()
      }
@@ -295,10 +264,9 @@ Rustfmt size:  74236 bytes
 -
      deferred_cast_checks: Vec<CastCheck<'db>>,
 -
--    // fields related to closure capture
+     // fields related to closure capture
      current_captures: Vec<CapturedItemWithoutTy<'db>>,
      /// A stack that has an entry for each projection in the current capture.
-     ///
      /// comment on `InferenceContext::sort_closures`
      closure_dependencies: FxHashMap<InternedClosureId, Vec<InternedClosureId>>,
      deferred_closures: FxHashMap<InternedClosureId, Vec<(Ty<'db>, Ty<'db>, Vec<Ty<'db>>, ExprId)>>,

--- a/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_infer_cast.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_infer_cast.chloro.rs
@@ -31,7 +31,6 @@ pub(crate) enum CastTy<'db> {
     Float,
     FnPtr,
     Ptr(Ty<'db>, Mutability),
-    // `DynStar` is Not supported yet in r-a
 }
 
 impl<'db> CastTy<'db> {
@@ -72,9 +71,6 @@ pub enum CastError {
     NeedViaThinPtr,
     NeedViaInt,
     NonScalar,
-    // We don't want to report errors with unknown types currently.
-    // UnknownCastPtrKind,
-    // UnknownExprPtrKind,
 }
 
 impl CastError {
@@ -361,8 +357,11 @@ impl<'db> CastCheck<'db> {
 
 #[derive(Debug, PartialEq, Eq)]
 enum PointerKind<'db> {
+    // thin pointer
     Thin,
+    // trait object
     VTable(BoundExistentialPredicates<'db>),
+    // slice
     Length,
     OfAlias,
     OfParam(ParamTy),

--- a/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_infer_cast.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_infer_cast.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 16583 bytes
-Chloro size:   16531 bytes
+Chloro size:   16417 bytes
 Rustfmt size:  16583 bytes
 
 ✗ Outputs DIFFER
@@ -29,6 +29,22 @@ Rustfmt size:  16583 bytes
  };
  
  #[derive(Debug)]
+     Float,
+     FnPtr,
+     Ptr(Ty<'db>, Mutability),
+-    // `DynStar` is Not supported yet in r-a
+ }
+ 
+ impl<'db> CastTy<'db> {
+     NeedViaThinPtr,
+     NeedViaInt,
+     NonScalar,
+-    // We don't want to report errors with unknown types currently.
+-    // UnknownCastPtrKind,
+-    // UnknownExprPtrKind,
+ }
+ 
+ impl CastError {
          }
  
          // Chalk doesn't support trait upcasting and fails to solve some obvious goals
@@ -45,14 +61,3 @@ Rustfmt size:  16583 bytes
          match (t_from, t_cast) {
              (_, CastTy::Int(Int::CEnum) | CastTy::FnPtr) => Err(CastError::NonScalar),
              (_, CastTy::Int(Int::Bool)) => Err(CastError::CastToBool),
- 
- #[derive(Debug, PartialEq, Eq)]
- enum PointerKind<'db> {
--    // thin pointer
-     Thin,
--    // trait object
-     VTable(BoundExistentialPredicates<'db>),
--    // slice
-     Length,
-     OfAlias,
-     OfParam(ParamTy),

--- a/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_infer_path.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_infer_path.chloro.rs
@@ -395,6 +395,8 @@ impl<'db> InferenceContext<'_, 'db> {
 
 #[derive(Debug)]
 enum ValuePathResolution<'db> {
+    // It's awkward to wrap a single ID in two enums, but we need both and this saves fallible
+    // conversion between them + `unwrap()`.
     GenericDef(ValueTyDefId, GenericDefId, GenericArgs<'db>),
     NonGeneric(Ty<'db>),
 }

--- a/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_infer_path.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_infer_path.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 16114 bytes
-Chloro size:   15965 bytes
+Chloro size:   16105 bytes
 Rustfmt size:  16341 bytes
 
 ✗ Outputs DIFFER
@@ -137,11 +137,3 @@ Rustfmt size:  16341 bytes
                  self.unify(impl_self_ty, ty);
                  impl_substs
              }
- 
- #[derive(Debug)]
- enum ValuePathResolution<'db> {
--    // It's awkward to wrap a single ID in two enums, but we need both and this saves fallible
--    // conversion between them + `unwrap()`.
-     GenericDef(ValueTyDefId, GenericDefId, GenericArgs<'db>),
-     NonGeneric(Ty<'db>),
- }

--- a/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_inhabitedness.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_inhabitedness.chloro.rs
@@ -51,6 +51,7 @@ pub(crate) fn is_enum_variant_uninhabited_from<'db>(
 struct UninhabitedFrom<'a, 'db> {
     target_mod: ModuleId,
     recursive_ty: FxHashSet<Ty<'db>>,
+    // guard for preventing stack overflow in non trivial non terminating types
     max_depth: usize,
     infcx: &'a InferCtxt<'db>,
     env: Arc<TraitEnvironment<'db>>,

--- a/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_inhabitedness.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_inhabitedness.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 6415 bytes
-Chloro size:   6220 bytes
+Chloro size:   6300 bytes
 Rustfmt size:  6524 bytes
 
 ✗ Outputs DIFFER
@@ -40,13 +40,6 @@ Rustfmt size:  6524 bytes
  /// Checks whether a variant is visibly uninhabited from a particular module.
  pub(crate) fn is_enum_variant_uninhabited_from<'db>(
      infcx: &InferCtxt<'db>,
- struct UninhabitedFrom<'a, 'db> {
-     target_mod: ModuleId,
-     recursive_ty: FxHashSet<Ty<'db>>,
--    // guard for preventing stack overflow in non trivial non terminating types
-     max_depth: usize,
-     infcx: &'a InferCtxt<'db>,
-     env: Arc<TraitEnvironment<'db>>,
  }
  
  const CONTINUE_OPAQUELY_INHABITED: ControlFlow<VisiblyUninhabited> = Continue(());

--- a/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_layout.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_layout.chloro.rs
@@ -75,6 +75,7 @@ pub type Variants = hir_def::layout::Variants<RustcFieldIdx, RustcEnumVariantIdx
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum LayoutError {
+    // FIXME: Remove more variants once they get added to LayoutCalculatorError
     BadCalc(LayoutCalculatorError<()>),
     HasErrorConst,
     HasErrorType,

--- a/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_layout.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_layout.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 14485 bytes
-Chloro size:   14366 bytes
+Chloro size:   14446 bytes
 Rustfmt size:  14808 bytes
 
 ✗ Outputs DIFFER
@@ -54,11 +54,6 @@ Rustfmt size:  14808 bytes
  pub type Variants = hir_def::layout::Variants<RustcFieldIdx, RustcEnumVariantIdx>;
  
  #[derive(Debug, PartialEq, Eq, Clone)]
- pub enum LayoutError {
--    // FIXME: Remove more variants once they get added to LayoutCalculatorError
-     BadCalc(LayoutCalculatorError<()>),
-     HasErrorConst,
-     HasErrorType,
      UserReprTooSmall,
  }
  

--- a/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_lower.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_lower.chloro.rs
@@ -85,6 +85,7 @@ struct ImplTraitLoweringState<'db> {
     /// bounds at the same time to get the IDs correct (without becoming too
     /// complicated).
     mode: ImplTraitLoweringMode,
+    // This is structured as a struct with fields and not as an enum because it helps with the borrow checker.
     opaque_type_data: Arena<ImplTrait<'db>>,
 }
 
@@ -113,20 +114,25 @@ pub enum LifetimeElisionKind<'db> {
     AnonymousCreateParameter {
         report_in_path: bool,
     },
+
     /// Replace all anonymous lifetimes by provided lifetime.
     Elided(Region<'db>),
+
     /// Give a hard error when either `&` or `'_` is written. Used to
     /// rule out things like `where T: Foo<'_>`. Does not imply an
     /// error on default object bounds (e.g., `Box<dyn Foo>`).
     AnonymousReportError,
+
     /// Resolves elided lifetimes to `'static` if there are no other lifetimes in scope,
     /// otherwise give a warning that the previous behavior of introducing a new early-bound
     /// lifetime is a bug and will be removed (if `only_lint` is enabled).
     StaticIfNoLifetimeInScope {
         only_lint: bool,
     },
+
     /// Signal we cannot find which should be the anonymous lifetime.
     ElisionFailure,
+
     /// Infer all elided lifetimes.
     Infer,
 }

--- a/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_lower.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_lower.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 87058 bytes
-Chloro size:   86556 bytes
+Chloro size:   86672 bytes
 Rustfmt size:  87058 bytes
 
 ✗ Outputs DIFFER
@@ -77,43 +77,26 @@ Rustfmt size:  87058 bytes
  };
  
  pub(crate) struct PathDiagnosticCallbackData(pub(crate) TypeRefId);
-     /// bounds at the same time to get the IDs correct (without becoming too
-     /// complicated).
-     mode: ImplTraitLoweringMode,
--    // This is structured as a struct with fields and not as an enum because it helps with the borrow checker.
-     opaque_type_data: Arena<ImplTrait<'db>>,
- }
- 
      /// struct Foo<'a> { x: &'a () }
      /// async fn foo(Foo { x: _ }: Foo<'_>) {}
      /// ```
 -    AnonymousCreateParameter { report_in_path: bool },
--
 +    AnonymousCreateParameter {
 +        report_in_path: bool,
 +    },
+ 
      /// Replace all anonymous lifetimes by provided lifetime.
      Elided(Region<'db>),
--
-     /// Give a hard error when either `&` or `'_` is written. Used to
-     /// rule out things like `where T: Foo<'_>`. Does not imply an
-     /// error on default object bounds (e.g., `Box<dyn Foo>`).
-     AnonymousReportError,
--
      /// Resolves elided lifetimes to `'static` if there are no other lifetimes in scope,
      /// otherwise give a warning that the previous behavior of introducing a new early-bound
      /// lifetime is a bug and will be removed (if `only_lint` is enabled).
 -    StaticIfNoLifetimeInScope { only_lint: bool },
--
 +    StaticIfNoLifetimeInScope {
 +        only_lint: bool,
 +    },
+ 
      /// Signal we cannot find which should be the anonymous lifetime.
      ElisionFailure,
--
-     /// Infer all elided lifetimes.
-     Infer,
- }
          )
      }
  

--- a/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_method_resolution.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_method_resolution.chloro.rs
@@ -46,6 +46,7 @@ use crate::{
 /// This is used as a key for indexing impls.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum TyFingerprint {
+    // These are lang item impls:
     Str,
     Slice,
     Array,
@@ -57,9 +58,11 @@ pub enum TyFingerprint {
     Int(IntTy),
     Uint(UintTy),
     Float(FloatTy),
+    // These can have user-defined impls:
     Adt(hir_def::AdtId),
     Dyn(TraitId),
     ForeignType(TypeAliasId),
+    // These only exist for trait impls
     Unit,
     Unnameable,
     Function(u32),
@@ -172,6 +175,7 @@ type TraitFpMapCollector = FxHashMap<TraitId, FxHashMap<Option<TyFingerprint>, V
 /// Trait impls defined or available in some crate.
 #[derive(Debug, Eq, PartialEq)]
 pub struct TraitImpls {
+    // If the `Option<TyFingerprint>` is `None`, the impl may apply to any self type.
     map: TraitFpMap,
 }
 

--- a/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_method_resolution.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_method_resolution.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 65944 bytes
-Chloro size:   65578 bytes
+Chloro size:   65780 bytes
 Rustfmt size:  65944 bytes
 
 ✗ Outputs DIFFER
@@ -64,23 +64,6 @@ Rustfmt size:  65944 bytes
  };
  
  /// This is used as a key for indexing impls.
- #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
- pub enum TyFingerprint {
--    // These are lang item impls:
-     Str,
-     Slice,
-     Array,
-     Int(IntTy),
-     Uint(UintTy),
-     Float(FloatTy),
--    // These can have user-defined impls:
-     Adt(hir_def::AdtId),
-     Dyn(TraitId),
-     ForeignType(TypeAliasId),
--    // These only exist for trait impls
-     Unit,
-     Unnameable,
-     Function(u32),
  ];
  
  type TraitFpMap = FxHashMap<TraitId, FxHashMap<Option<TyFingerprint>, Box<[ImplId]>>>;
@@ -88,12 +71,6 @@ Rustfmt size:  65944 bytes
  type TraitFpMapCollector = FxHashMap<TraitId, FxHashMap<Option<TyFingerprint>, Vec<ImplId>>>;
  
  /// Trait impls defined or available in some crate.
- #[derive(Debug, Eq, PartialEq)]
- pub struct TraitImpls {
--    // If the `Option<TyFingerprint>` is `None`, the impl may apply to any self type.
-     map: TraitFpMap,
- }
- 
      }
  
      /// Queries whether `self_ty` has potentially applicable implementations of `trait_`.

--- a/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_mir.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_mir.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 49552 bytes
-Chloro size:   48418 bytes
+Chloro size:   49318 bytes
 Rustfmt size:  50490 bytes
 
 ✗ Outputs DIFFER
@@ -81,20 +81,6 @@ Rustfmt size:  50490 bytes
  pub type LocalId<'db> = Idx<Local<'db>>;
  
  fn return_slot<'db>() -> LocalId<'db> {
- #[derive(Debug, PartialEq, Eq, Clone)]
- pub struct Operand<'db> {
-     kind: OperandKind<'db>,
--    // FIXME : This should actually just be of type `MirSpan`.
-     span: Option<MirSpan>,
- }
- 
-     /// Before drop elaboration, the type of the place must be `Copy`. After drop elaboration there
-     /// is no such requirement.
-     Copy(Place<'db>),
--
-     /// Creates a value by performing loading the place, just like the `Copy` operand.
-     ///
-     /// This *may* additionally overwrite the place with `uninit` bytes, depending on how we decide
      /// [UCG#188]: https://github.com/rust-lang/unsafe-code-guidelines/issues/188
      Move(Place<'db>),
      /// Constants are already semantically values, and remain unchanged.
@@ -118,15 +104,11 @@ Rustfmt size:  50490 bytes
          Operand::from_bytes(Box::default(), ty)
      }
  }
- pub enum ProjectionElem<V, T> {
-     Deref,
-     Field(Either<FieldId, TupleFieldId>),
--    // FIXME: get rid of this, and use FieldId for tuples and closures
+     // FIXME: get rid of this, and use FieldId for tuples and closures
      ClosureField(usize),
      Index(V),
 -    ConstantIndex { offset: u64, from_end: bool },
 -    Subslice { from: u64, to: u64 },
--    //Downcast(Option<Symbol>, VariantIdx),
 +    ConstantIndex {
 +        offset: u64,
 +        from_end: bool,
@@ -135,9 +117,9 @@ Rustfmt size:  50490 bytes
 +        from: u64,
 +        to: u64,
 +    },
+     //Downcast(Option<Symbol>, VariantIdx),
      OpaqueCast(T),
  }
- 
          let db = interner.db;
  
          // we only bail on mir building when there are type mismatches
@@ -215,22 +197,29 @@ Rustfmt size:  50490 bytes
      }
  }
  
+     Adt(VariantId, GenericArgs<'db>),
+     Union(UnionId, FieldId),
+     Closure(Ty<'db>),
+-    //Coroutine(LocalDefId, SubstsRef, Movability),
+ }
+ 
+ #[derive(Debug, Clone, Hash, PartialEq, Eq)]
      /// Possible values. The locations to branch to in each case
      /// are found in the corresponding indices from the `targets` vector.
      values: SmallVec<[u128; 1]>,
 -
-     /// Possible branch sites. The last element of this vector is used
-     /// for the otherwise branch, so targets.len() == values.len() + 1
-     /// should hold.
--    //
--    // This invariant is quite non-obvious and also could be improved.
--    // One way to make this invariant is to have something like this instead:
--    //
--    // branches: Vec<(ConstInt, BasicBlock)>,
--    // otherwise: Option<BasicBlock> // exhaustive if None
--    //
--    // However we’ve decided to keep this as-is until we figure a case
--    // where some other approach seems to be strictly better than other.
+-    /// Possible branch sites. The last element of this vector is used
+-    /// for the otherwise branch, so targets.len() == values.len() + 1
+-    /// should hold.
+     //
+     // This invariant is quite non-obvious and also could be improved.
+     // One way to make this invariant is to have something like this instead:
+     //
+     // However we’ve decided to keep this as-is until we figure a case
+     // where some other approach seems to be strictly better than other.
++    /// Possible branch sites. The last element of this vector is used
++    /// for the otherwise branch, so targets.len() == values.len() + 1
++    /// should hold.
      targets: SmallVec<[BasicBlockId<'db>; 2]>,
  }
  
@@ -248,101 +237,28 @@ Rustfmt size:  50490 bytes
  pub enum TerminatorKind<'db> {
      /// Block has one successor; we continue execution there.
 -    Goto { target: BasicBlockId<'db> },
--
 +    Goto {
 +        target: BasicBlockId<'db>,
 +    },
+ 
      /// Switches based on the computed value.
      ///
-     /// First, evaluates the `discr` operand. The type of the operand must be a signed or unsigned
      SwitchInt {
          /// The discriminant value being tested.
          discr: Operand<'db>,
 -
          targets: SwitchTargets<'db>,
      },
--
-     /// Indicates that the landing pad is finished and that the process should continue unwinding.
-     ///
-     /// Like a return, this marks the end of this invocation of the function.
-     /// Only permitted in cleanup blocks. `Resume` is not permitted with `-C unwind=abort` after
-     /// deaggregation runs.
-     UnwindResume,
--
-     /// Indicates that the landing pad is finished and that the process should abort.
-     ///
-     /// Used to prevent unwinding for foreign items or with `-C unwind=abort`. Only permitted in
-     /// cleanup blocks.
-     Abort,
--
-     /// Returns from the function.
-     ///
-     /// Like function calls, the exact semantics of returns in Rust are unclear. Returning very
-     /// `CoroutineState::Returned(_0)` to be created (as if by an `Aggregate` rvalue) and assigned
-     /// to the return place.
-     Return,
--
-     /// Indicates a terminator that can never be reached.
-     ///
-     /// Executing this terminator is UB.
-     Unreachable,
--
-     /// The behavior of this statement differs significantly before and after drop elaboration.
-     /// After drop elaboration, `Drop` executes the drop glue for the specified place, after which
-     /// it continues execution/unwinds at the given basic blocks. It is possible that executing drop
-         target: BasicBlockId<'db>,
-         unwind: Option<BasicBlockId<'db>>,
+ 
+         /// `true` if this is from a call in HIR rather than from an overloaded
+         /// operator. True for overloaded function call.
+         from_hir_call: bool,
+-        // This `Span` is the span of the function, without the dot and receiver
+-        // (e.g. `foo(a, b)` in `x.foo(a, b)`
+-        //fn_span: Span,
      },
--
-     /// Drops the place and assigns a new value to it.
-     ///
-     /// This first performs the exact same operation as the pre drop-elaboration `Drop` terminator;
-         target: BasicBlockId<'db>,
-         unwind: Option<BasicBlockId<'db>>,
-     },
--
-     /// Roughly speaking, evaluates the `func` operand and the arguments, and starts execution of
-     /// the referred to function. The operand types must match the argument types of the function.
-     /// The return place type must match the return type. The type of the `func` operand must be
-         // (e.g. `foo(a, b)` in `x.foo(a, b)`
-         //fn_span: Span,
-     },
--
+ 
      /// Evaluates the operand, which must have type `bool`. If it is not equal to `expected`,
-     /// initiates a panic. Initiating a panic corresponds to a `Call` terminator with some
-     /// unspecified constant as the function to call, all the operands stored in the `AssertMessage`
-     Assert {
-         cond: Operand<'db>,
-         expected: bool,
--        //msg: AssertMessage,
-         target: BasicBlockId<'db>,
-         cleanup: Option<BasicBlockId<'db>>,
-     },
--
-     /// Marks a suspend point.
-     ///
-     /// Like `Return` terminators in coroutine bodies, this computes `value` and then a
-         /// Cleanup to be done if the coroutine is dropped at this suspend point.
-         drop: Option<BasicBlockId<'db>>,
-     },
--
-     /// Indicates the end of dropping a coroutine.
-     ///
-     /// Semantically just a `return` (from the coroutines drop glue). Only permitted in the same situations
-     /// **Needs clarification**: Are there type system constraints on these terminators? Should
-     /// there be a "block type" like `cleanup` blocks for them?
-     CoroutineDrop,
--
-     /// A block where control flow only ever takes one real path, but borrowck needs to be more
-     /// conservative.
-     ///
-         /// practice.
-         imaginary_target: BasicBlockId<'db>,
-     },
--
-     /// A terminator for blocks that only take one path in reality, but where we reserve the right
-     /// to unwind in borrowck, even if it won't happen in practice. This can arise in infinite loops
-     /// with no function calls for example.
      },
  }
  
@@ -350,15 +266,8 @@ Rustfmt size:  50490 bytes
  #[derive(Debug, PartialEq, Eq, Clone, Copy, PartialOrd, Ord)]
  pub enum BorrowKind {
      /// Data must be immutable and is aliasable.
-     Shared,
--
-     /// The immediately borrowed place must be immutable, but projections from
-     /// it don't need to be. For example, a shallow borrow of `a.b` doesn't
-     /// conflict with a mutable borrow of `a.b.c`.
-     /// mutating `(*x as Some).0` can't affect the discriminant of `x`.
-     /// We can also report errors with this kind of borrow differently.
      Shallow,
--
+ 
      /// Data is mutable and not aliasable.
 -    Mut { kind: MutBorrowKind },
 +    Mut {
@@ -416,22 +325,10 @@ Rustfmt size:  50490 bytes
          }
      }
  }
- pub enum Rvalue<'db> {
-     /// Yields the operand unchanged
-     Use(Operand<'db>),
--
-     /// Creates an array where each element is the value of the operand.
-     ///
-     /// Corresponds to source code like `[x; 32]`.
-     Repeat(Operand<'db>, Const<'db>),
--
-     /// Creates a reference of the indicated kind to the place.
-     ///
-     /// There is not much to document here, because besides the obvious parts the semantics of this
-     ///
      /// `Shallow` borrows are disallowed after drop lowering.
      Ref(BorrowKind, Place<'db>),
--
+ 
++    // ThreadLocalRef(DefId),
      /// Creates a pointer/reference to the given thread local.
      ///
      /// The yielded type is a `*mut T` if the static is mutable, otherwise if the static is extern a
@@ -440,7 +337,8 @@ Rustfmt size:  50490 bytes
      /// nature of this operation?
 -    // ThreadLocalRef(DefId),
      ThreadLocalRef(std::convert::Infallible),
--
+ 
++    // AddressOf(Mutability, Place),
      /// Creates a pointer with the indicated mutability to the place.
      ///
      /// This is generated by pointer casts like `&v as *const _` or raw address of expressions like
@@ -449,22 +347,12 @@ Rustfmt size:  50490 bytes
      /// model.
 -    // AddressOf(Mutability, Place),
      AddressOf(std::convert::Infallible),
--
+ 
      /// Yields the length of the place, as a `usize`.
-     ///
-     /// If the type of the place is an array, this is the array length. For slices (`[T]`, not
-     /// `&[T]`) this accesses the place's metadata to determine the length. This rvalue is
-     /// ill-formed for places of other types.
-     Len(Place<'db>),
--
-     /// Performs essentially all of the casts that can be performed via `as`.
-     ///
-     /// This allows for casts from/to a variety of types.
-     /// **FIXME**: Document exactly which `CastKind`s allow which types of casts. Figure out why
-     /// `ArrayToPointer` and `MutToConstPointer` are special.
      Cast(CastKind, Operand<'db>, Ty<'db>),
--
--    // FIXME link to `pointer::offset` when it hits stable.
+ 
+     // FIXME link to `pointer::offset` when it hits stable.
++    //BinaryOp(BinOp, Box<(Operand, Operand)>),
      /// * `Offset` has the same semantics as `pointer::offset`, except that the second
      ///   parameter may be a `usize` as well.
      /// * The comparison operations accept `bool`s, `char`s, signed or unsigned integers, floats,
@@ -473,65 +361,18 @@ Rustfmt size:  50490 bytes
      ///   matching types and return a value of that type.
 -    //BinaryOp(BinOp, Box<(Operand, Operand)>),
      BinaryOp(std::convert::Infallible),
--
+ 
      /// Same as `BinaryOp`, but yields `(T, bool)` with a `bool` indicating an error condition.
-     ///
-     /// When overflow checking is disabled and we are generating run-time code, the error condition
-     ///
      /// Other combinations of types and operators are unsupported.
      CheckedBinaryOp(BinOp, Operand<'db>, Operand<'db>),
--
-     /// Computes a value as described by the operation.
--    //NullaryOp(NullOp, Ty),
+ 
+-    /// Computes a value as described by the operation.
+     //NullaryOp(NullOp, Ty),
++    /// Computes a value as described by the operation.
      NullaryOp(std::convert::Infallible),
--
+ 
      /// Exactly like `BinaryOp`, but less operands.
-     ///
-     /// Also does two's-complement arithmetic. Negation requires a signed integer or a float;
-     /// bitwise not requires a signed integer, unsigned integer, or bool. Both operation kinds
-     /// return a value with the same type as their operand.
-     UnaryOp(UnOp, Operand<'db>),
--
-     /// Computes the discriminant of the place, returning it as an integer of type
-     /// [`discriminant_ty`]. Returns zero for types without discriminant.
-     ///
-     /// [#91095]: https://github.com/rust-lang/rust/issues/91095
-     /// [`discriminant_for_variant`]: crate::ty::Ty::discriminant_for_variant
-     Discriminant(Place<'db>),
--
-     /// Creates an aggregate value, like a tuple or struct.
-     ///
-     /// This is needed because dataflow analysis needs to distinguish
-     /// Disallowed after deaggregation for all aggregate kinds except `Array` and `Coroutine`. After
-     /// coroutine lowering, `Coroutine` aggregate kinds are disallowed too.
-     Aggregate(AggregateKind<'db>, Box<[Operand<'db>]>),
--
-     /// Transmutes a `*mut u8` into shallow-initialized `Box<T>`.
-     ///
-     /// This is different from a normal transmute because dataflow analysis will treat the box as
-     /// initialized but its content as uninitialized. Like other pointer casts, this in general
-     /// affects alias analysis.
-     ShallowInitBox(Operand<'db>, Ty<'db>),
--
-     /// NON STANDARD: allocates memory with the type's layout, and shallow init the box with the resulting pointer.
-     ShallowInitBoxWithAlloc(Ty<'db>),
--
-     /// A CopyForDeref is equivalent to a read from a place at the
-     /// codegen level, but is treated specially by drop elaboration. When such a read happens, it
-     /// is guaranteed (via nature of the mir_opt `Derefer` in rustc_mir_transform/src/deref_separator)
- pub enum StatementKind<'db> {
-     Assign(Place<'db>, Rvalue<'db>),
-     FakeRead(Place<'db>),
--    //SetDiscriminant {
--    //    place: Box<Place>,
--    //    variant_index: VariantIdx,
--    //},
-     Deinit(Place<'db>),
-     StorageLive(LocalId<'db>),
-     StorageDead(LocalId<'db>),
--    //Retag(RetagKind, Box<Place>),
--    //AscribeUserType(Place, UserTypeProjection, Variance),
--    //Intrinsic(Box<NonDivergingIntrinsic>),
+     //Intrinsic(Box<NonDivergingIntrinsic>),
      Nop,
  }
 +

--- a/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_mir_eval.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_mir_eval.chloro.rs
@@ -195,6 +195,7 @@ pub struct Evaluator<'db> {
     cached_fn_mut_trait_func: Option<FunctionId>,
     cached_fn_once_trait_func: Option<FunctionId>,
     crate_id: Crate,
+    // FIXME: This is a workaround, see the comment on `interpret_mir`
     assert_placeholder_ty_is_unused: bool,
     /// A general limit on execution, to prevent non terminating programs from breaking r-a main process
     execution_limit: usize,
@@ -351,6 +352,7 @@ pub enum MirEvalError<'db> {
     /// then use this type of error.
     UndefinedBehavior(String),
     Panic(String),
+    // FIXME: This should be folded into ConstEvalError?
     MirLowerError(FunctionId, MirLowerError<'db>),
     MirLowerErrorForClosure(InternedClosureId, MirLowerError<'db>),
     TypeIsUnsized(Ty<'db>, &'static str),

--- a/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_mir_eval.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_mir_eval.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 131517 bytes
-Chloro size:   130271 bytes
+Chloro size:   130399 bytes
 Rustfmt size:  131517 bytes
 
 ✗ Outputs DIFFER
@@ -100,13 +100,6 @@ Rustfmt size:  131517 bytes
  
      fn id(&mut self, ty: Ty<'db>) -> usize {
          if let Some(it) = self.ty_to_id.get(&ty) {
-     cached_fn_mut_trait_func: Option<FunctionId>,
-     cached_fn_once_trait_func: Option<FunctionId>,
-     crate_id: Crate,
--    // FIXME: This is a workaround, see the comment on `interpret_mir`
-     assert_placeholder_ty_is_unused: bool,
-     /// A general limit on execution, to prevent non terminating programs from breaking r-a main process
-     execution_limit: usize,
      Invalid(usize),
  }
  
@@ -139,12 +132,6 @@ Rustfmt size:  131517 bytes
  #[cfg(target_pointer_width = "32")]
  const HEAP_OFFSET: usize = 1 << 29;
  
-     /// then use this type of error.
-     UndefinedBehavior(String),
-     Panic(String),
--    // FIXME: This should be folded into ConstEvalError?
-     MirLowerError(FunctionId, MirLowerError<'db>),
-     MirLowerErrorForClosure(InternedClosureId, MirLowerError<'db>),
      TypeIsUnsized(Ty<'db>, &'static str),
      NotSupported(String),
      InvalidConst(Const<'db>),

--- a/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_mir_lower.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_mir_lower.chloro.rs
@@ -112,6 +112,8 @@ pub enum MirLowerError<'db> {
     UnresolvedLabel,
     UnresolvedUpvar(Place<'db>),
     InaccessibleLocal,
+
+    // monomorphization errors:
     GenericArgNotProvided(GenericParamId, GenericArgs<'db>),
 }
 

--- a/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_mir_lower.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_mir_lower.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 95826 bytes
-Chloro size:   95572 bytes
+Chloro size:   95605 bytes
 Rustfmt size:  95826 bytes
 
 ✗ Outputs DIFFER
@@ -90,13 +90,6 @@ Rustfmt size:  95826 bytes
  #[derive(Debug, Clone, PartialEq, Eq)]
  pub enum MirLowerError<'db> {
      ConstEvalError(Box<str>, Box<ConstEvalError<'db>>),
-     UnresolvedLabel,
-     UnresolvedUpvar(Place<'db>),
-     InaccessibleLocal,
--
--    // monomorphization errors:
-     GenericArgNotProvided(GenericParamId, GenericArgs<'db>),
- }
  
  /// A token to ensuring that each drop scope is popped at most once, thanks to the compiler that checks moves.
  struct DropScopeToken;

--- a/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_next_solver_consts.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_next_solver_consts.chloro.rs
@@ -116,6 +116,7 @@ pub type PlaceholderConst = Placeholder<BoundConst>;
 
 #[derive(Copy, Clone, Hash, Eq, PartialEq)]
 pub struct ParamConst {
+    // FIXME: See `ParamTy`.
     pub id: ConstParamId,
     pub index: u32,
 }
@@ -171,6 +172,7 @@ impl ParamConst {
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, TypeFoldable, TypeVisitable)]
 pub struct ValueConst<'db> {
     pub ty: Ty<'db>,
+    // FIXME: Should we ignore this for TypeVisitable, TypeFoldable?
     #[type_visitable(ignore)]
     #[type_foldable(identity)]
     pub value: Valtree<'db>,

--- a/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_next_solver_consts.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_next_solver_consts.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 14262 bytes
-Chloro size:   14271 bytes
+Chloro size:   14369 bytes
 Rustfmt size:  14546 bytes
 
 ✗ Outputs DIFFER
@@ -30,13 +30,6 @@ Rustfmt size:  14546 bytes
      }
  
      pub fn new_valtree(
- 
- #[derive(Copy, Clone, Hash, Eq, PartialEq)]
- pub struct ParamConst {
--    // FIXME: See `ParamTy`.
-     pub id: ConstParamId,
-     pub index: u32,
- }
          });
  
          // N.B. it may be tempting to fix ICEs by making this function return
@@ -52,13 +45,6 @@ Rustfmt size:  14546 bytes
          // to modify this function.
          let ty = candidates.next().unwrap_or_else(|| {
              panic!("cannot find `{self:?}` in param-env: {env:#?}");
- #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, TypeFoldable, TypeVisitable)]
- pub struct ValueConst<'db> {
-     pub ty: Ty<'db>,
--    // FIXME: Should we ignore this for TypeVisitable, TypeFoldable?
-     #[type_visitable(ignore)]
-     #[type_foldable(identity)]
-     pub value: Valtree<'db>,
      ) -> Result<Self, F::Error> {
          folder.try_fold_const(self)
      }

--- a/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_next_solver_def_id.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_next_solver_def_id.chloro.rs
@@ -29,6 +29,7 @@ pub enum SolverDefId {
     InternedCoroutineId(InternedCoroutineId),
     InternedOpaqueTyId(InternedOpaqueTyId),
     EnumVariantId(EnumVariantId),
+    // FIXME(next-solver): Do we need the separation of `Ctor`? It duplicates some variants.
     Ctor(Ctor),
 }
 

--- a/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_next_solver_def_id.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_next_solver_def_id.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 11678 bytes
-Chloro size:   11024 bytes
+Chloro size:   11117 bytes
 Rustfmt size:  12164 bytes
 
 ✗ Outputs DIFFER
@@ -15,13 +15,6 @@ Rustfmt size:  12164 bytes
  use super::DbInterner;
  
  #[derive(Debug, PartialOrd, Ord, Clone, Copy, PartialEq, Eq, Hash, salsa::Supertype)]
-     InternedCoroutineId(InternedCoroutineId),
-     InternedOpaqueTyId(InternedOpaqueTyId),
-     EnumVariantId(EnumVariantId),
--    // FIXME(next-solver): Do we need the separation of `Ctor`? It duplicates some variants.
-     Ctor(Ctor),
- }
- 
          let interner = DbInterner::conjure();
          let db = interner.db;
          match *self {

--- a/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_next_solver_fulfill_errors.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_next_solver_fulfill_errors.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 50684 bytes
-Chloro size:   50099 bytes
+Chloro size:   50701 bytes
 Rustfmt size:  50684 bytes
 
 ✗ Outputs DIFFER
@@ -42,6 +42,7 @@ Rustfmt size:  50684 bytes
      Project(MismatchedProjectionTypes<'db>),
 -    Subtype(ExpectedFound<Ty<'db>>, TypeError<'db>), // always comes from a SubtypePredicate
 +    Subtype(ExpectedFound<Ty<'db>>, TypeError<'db>),
++    // always comes from a SubtypePredicate
      ConstEquate(ExpectedFound<Const<'db>>, TypeError<'db>),
      Ambiguity {
          /// Overflow is only `Some(suggest_recursion_limit)` when using the next generation
@@ -96,23 +97,6 @@ Rustfmt size:  50684 bytes
          // and therefore is treated as rigid.
          if let Some(PredicateKind::AliasRelate(lhs, rhs, _)) = pred.kind().no_bound_vars() {
              goal.infcx().visit_proof_tree_at_depth(
- 
- #[derive(Debug, Copy, Clone)]
- enum ChildMode<'db> {
--    // Try to derive an `ObligationCause::{ImplDerived,BuiltinDerived}`,
--    // and skip all `GoalSource::Misc`, which represent useless obligations
--    // such as alias-eq which may not hold.
-     Trait(PolyTraitPredicate<'db>),
--    // Try to derive an `ObligationCause::{ImplDerived,BuiltinDerived}`,
--    // and skip all `GoalSource::Misc`, which represent useless obligations
--    // such as alias-eq which may not hold.
-     Host(Binder<'db, HostEffectPredicate<DbInterner<'db>>>),
--    // Skip trying to derive an `ObligationCause` from this obligation, and
--    // report *all* sub-obligations as if they came directly from the parent
--    // obligation.
-     PassThrough,
- }
- 
          Interner, TypeSuperVisitable, TypeVisitable, TypeVisitableExt, TypeVisitor,
      };
      use tracing::{debug, instrument};

--- a/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_next_solver_infer_canonical_canonicalizer.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_next_solver_infer_canonical_canonicalizer.chloro.rs
@@ -309,6 +309,8 @@ struct Canonicalizer<'cx, 'db> {
     tcx: DbInterner<'db>,
     variables: SmallVec<[CanonicalVarKind<'db>; 8]>,
     query_state: &'cx mut OriginalQueryValues<'db>,
+    // Note that indices is only used once `var_values` is big enough to be
+    // heap-allocated.
     indices: FxHashMap<GenericArg<'db>, BoundVar>,
     /// Maps each `sub_unification_table_root_var` to the index of the first
     /// variable which used it.

--- a/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_next_solver_infer_canonical_canonicalizer.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_next_solver_infer_canonical_canonicalizer.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 29589 bytes
-Chloro size:   29449 bytes
+Chloro size:   29548 bytes
 Rustfmt size:  29841 bytes
 
 ✗ Outputs DIFFER
@@ -65,14 +65,6 @@ Rustfmt size:  29841 bytes
      }
  
      fn any(&self) -> bool {
-     tcx: DbInterner<'db>,
-     variables: SmallVec<[CanonicalVarKind<'db>; 8]>,
-     query_state: &'cx mut OriginalQueryValues<'db>,
--    // Note that indices is only used once `var_values` is big enough to be
--    // heap-allocated.
-     indices: FxHashMap<GenericArg<'db>, BoundVar>,
-     /// Maps each `sub_unification_table_root_var` to the index of the first
-     /// variable which used it.
      sub_root_lookup_table: FxHashMap<TyVid, usize>,
      canonicalize_mode: &'cx dyn CanonicalizeMode,
      needs_canonical_flags: TypeFlags,

--- a/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_next_solver_infer_canonical_instantiate.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_next_solver_infer_canonical_instantiate.chloro.rs
@@ -107,7 +107,10 @@ where
 /// Replaces the bound vars in a canonical binder with var values.
 struct CanonicalInstantiator<'db, 'a> {
     tcx: DbInterner<'db>,
+    // The values that the bound vars are being instantiated with.
     var_values: &'a [GenericArg<'db>],
+    // Because we use `BoundVarIndexKind::Canonical`, we can cache
+    // based only on the entire ty, not worrying about a `DebruijnIndex`
     cache: FxHashMap<Ty<'db>, Ty<'db>>,
 }
 

--- a/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_next_solver_infer_canonical_instantiate.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_next_solver_infer_canonical_instantiate.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 6139 bytes
-Chloro size:   5932 bytes
+Chloro size:   6139 bytes
 Rustfmt size:  6179 bytes
 
 ✗ Outputs DIFFER
@@ -38,14 +38,12 @@ Rustfmt size:  6179 bytes
  struct CanonicalInstantiator<'db, 'a> {
      tcx: DbInterner<'db>,
 -
--    // The values that the bound vars are being instantiated with.
+     // The values that the bound vars are being instantiated with.
      var_values: &'a [GenericArg<'db>],
 -
--    // Because we use `BoundVarIndexKind::Canonical`, we can cache
--    // based only on the entire ty, not worrying about a `DebruijnIndex`
+     // Because we use `BoundVarIndexKind::Canonical`, we can cache
+     // based only on the entire ty, not worrying about a `DebruijnIndex`
      cache: FxHashMap<Ty<'db>, Ty<'db>>,
- }
- 
      }
  
      fn fold_predicate(&mut self, p: Predicate<'db>) -> Predicate<'db> {

--- a/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_next_solver_infer_mod.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_next_solver_infer_mod.chloro.rs
@@ -271,8 +271,10 @@ pub struct TypeTrace<'db> {
 pub enum BoundRegionConversionTime {
     /// when a fn is called
     FnCall,
+
     /// when two higher-ranked types are compared
     HigherRankedType,
+
     /// when projecting an associated type
     AssocTypeProjection(SolverDefId),
 }
@@ -1165,6 +1167,7 @@ pub enum TyOrConstInferVar {
     TyInt(IntVid),
     /// Equivalent to `Infer(FloatVar(_))`.
     TyFloat(FloatVid),
+
     /// Equivalent to `ConstKind::Infer(InferConst::Var(_))`.
     Const(ConstVid),
 }

--- a/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_next_solver_infer_mod.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_next_solver_infer_mod.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 49754 bytes
-Chloro size:   49345 bytes
+Chloro size:   49348 bytes
 Rustfmt size:  49754 bytes
 
 ✗ Outputs DIFFER
@@ -178,16 +178,6 @@ Rustfmt size:  49754 bytes
      /// What is the innermost universe we have created? Starts out as
      /// `UniverseIndex::root()` but grows from there as we enter
      /// universal quantifiers.
- pub enum BoundRegionConversionTime {
-     /// when a fn is called
-     FnCall,
--
-     /// when two higher-ranked types are compared
-     HigherRankedType,
--
-     /// when projecting an associated type
-     AssocTypeProjection(SolverDefId),
- }
          };
  
          // This can get called from typeck (by euv), and `moves_by_default`
@@ -212,13 +202,6 @@ Rustfmt size:  49754 bytes
      pub fn instantiate_binder_with_fresh_vars<T>(
          &self,
          _lbrct: BoundRegionConversionTime,
-     TyInt(IntVid),
-     /// Equivalent to `Infer(FloatVar(_))`.
-     TyFloat(FloatVid),
--
-     /// Equivalent to `ConstKind::Infer(InferConst::Var(_))`.
-     Const(ConstVid),
- }
          a: TraitRef<'db>,
          b: TraitRef<'db>,
      ) -> TypeTrace<'db> {

--- a/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_next_solver_infer_region_constraints_mod.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_next_solver_infer_region_constraints_mod.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 24418 bytes
-Chloro size:   23656 bytes
+Chloro size:   24417 bytes
 Rustfmt size:  24577 bytes
 
 ✗ Outputs DIFFER
@@ -62,45 +62,6 @@ Rustfmt size:  24577 bytes
      /// A "verify" is something that we need to verify after inference
      /// is done, but which does not directly affect inference in any
      /// way.
- pub enum Constraint<'db> {
-     /// A region variable is a subregion of another.
-     VarSubVar(RegionVid, RegionVid),
--
-     /// A concrete region is a subregion of region variable.
-     RegSubVar(Region<'db>, RegionVid),
--
-     /// A region variable is a subregion of a concrete region. This does not
-     /// directly affect inference, but instead is checked after
-     /// inference is complete.
-     VarSubReg(RegionVid, Region<'db>),
--
-     /// A constraint where neither side is a variable. This does not
-     /// directly affect inference, but instead is checked after
-     /// inference is complete.
- pub enum VerifyBound<'db> {
-     /// See [`VerifyIfEq`] docs
-     IfEq(Binder<'db, VerifyIfEq<'db>>),
--
-     /// Given a region `R`, expands to the function:
-     ///
-     /// ```ignore (pseudo-rust)
-     /// This is used when we can establish that `G: R` -- therefore,
-     /// if `R: min`, then by transitivity `G: min`.
-     OutlivedBy(Region<'db>),
--
-     /// Given a region `R`, true if it is `'empty`.
-     IsEmpty,
--
-     /// Given a set of bounds `B`, expands to the function:
-     ///
-     /// ```ignore (pseudo-rust)
-     /// In other words, if we meet some bound in `B`, that suffices.
-     /// This is used when all the bounds in `B` are known to apply to `G`.
-     AnyBound(Vec<VerifyBound<'db>>),
--
-     /// Given a set of bounds `B`, expands to the function:
-     ///
-     /// ```ignore (pseudo-rust)
  pub struct VerifyIfEq<'db> {
      /// Type which must match the generic `G`
      pub ty: Ty<'db>,
@@ -108,38 +69,6 @@ Rustfmt size:  24577 bytes
      /// Bound that applies if `ty` is equal.
      pub bound: Region<'db>,
  }
- pub(crate) enum UndoLog<'db> {
-     /// We added `RegionVid`.
-     AddVar(RegionVid),
--
-     /// We added the given `constraint`.
-     AddConstraint(usize),
--
-     /// We added the given `verify`.
-     #[expect(dead_code, reason = "this is used in rustc")]
-     AddVerify(usize),
--
-     /// We added a GLB/LUB "combination variable".
-     AddCombination(CombineMapType, TwoRegions<'db>),
- }
- 
- #[derive(Debug, Clone)]
- pub struct RegionVariableInfo {
--    // FIXME: This is only necessary for `fn take_and_reset_data` and
--    // `lexical_region_resolve`. We should rework `lexical_region_resolve`
--    // in the near/medium future anyways and could move the unverse info
--    // for `fn take_and_reset_data` into a separate table which is
--    // only populated when needed.
--    //
--    // For both of these cases it is fine that this can diverge from the
--    // actual universe of the variable, which is directly stored in the
--    // unification table for unknown region variables. At some point we could
--    // stop emitting bidirectional outlives constraints if equate succeeds.
--    // This would be currently unsound as it would cause us to drop the universe
--    // changes in `lexical_region_resolve`.
-     pub universe: UniverseIndex,
- }
- 
          &'a mut self,
          undo_log: &'a mut InferCtxtUndoLogs<'db>,
      ) -> RegionConstraintCollector<'db, 'a> {

--- a/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_next_solver_infer_relate_lattice.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_next_solver_infer_relate_lattice.chloro.rs
@@ -50,8 +50,10 @@ impl LatticeOpKind {
 /// A greatest lower bound" (common subtype) or least upper bound (common supertype).
 pub(crate) struct LatticeOp<'infcx, 'db> {
     infcx: &'infcx InferCtxt<'db>,
+    // Immutable fields
     trace: TypeTrace<'db>,
     param_env: ParamEnv<'db>,
+    // Mutable fields
     kind: LatticeOpKind,
     obligations: PredicateObligations<'db>,
 }

--- a/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_next_solver_infer_relate_lattice.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_next_solver_infer_relate_lattice.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 9566 bytes
-Chloro size:   9166 bytes
+Chloro size:   9212 bytes
 Rustfmt size:  10026 bytes
 
 ✗ Outputs DIFFER
@@ -29,16 +29,6 @@ Rustfmt size:  10026 bytes
      AliasTy, Binder, Const, DbInterner, Goal, ParamEnv, Predicate, PredicateKind, Region, Span, Ty,
      TyKind,
  };
- /// A greatest lower bound" (common subtype) or least upper bound (common supertype).
- pub(crate) struct LatticeOp<'infcx, 'db> {
-     infcx: &'infcx InferCtxt<'db>,
--    // Immutable fields
-     trace: TypeTrace<'db>,
-     param_env: ParamEnv<'db>,
--    // Mutable fields
-     kind: LatticeOpKind,
-     obligations: PredicateObligations<'db>,
- }
          param_env: ParamEnv<'db>,
          kind: LatticeOpKind,
      ) -> LatticeOp<'infcx, 'db> {

--- a/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_next_solver_infer_select.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_next_solver_infer_select.chloro.rs
@@ -188,11 +188,13 @@ pub(crate) type SelectionResult<'db, T> = Result<Option<T>, SelectionError<'db>>
 pub(crate) enum ImplSource<'db, N> {
     /// ImplSource identifying a particular impl.
     UserDefined(ImplSourceUserDefinedData<'db, N>),
+
     /// Successful resolution to an obligation provided by the caller
     /// for some type parameter. The `Vec<N>` represents the
     /// obligations incurred from normalizing the where-clause (if
     /// any).
     Param(Vec<N>),
+
     /// Successful resolution for a builtin impl.
     Builtin(BuiltinImplSource, Vec<N>),
 }

--- a/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_next_solver_infer_select.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_next_solver_infer_select.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 16020 bytes
-Chloro size:   16049 bytes
+Chloro size:   16051 bytes
 Rustfmt size:  16174 bytes
 
 ✗ Outputs DIFFER
@@ -23,19 +23,6 @@ Rustfmt size:  16174 bytes
      },
  };
  
- pub(crate) enum ImplSource<'db, N> {
-     /// ImplSource identifying a particular impl.
-     UserDefined(ImplSourceUserDefinedData<'db, N>),
--
-     /// Successful resolution to an obligation provided by the caller
-     /// for some type parameter. The `Vec<N>` represents the
-     /// obligations incurred from normalizing the where-clause (if
-     /// any).
-     Param(Vec<N>),
--
-     /// Successful resolution for a builtin impl.
-     Builtin(BuiltinImplSource, Vec<N>),
- }
      }
  }
  

--- a/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_next_solver_infer_traits.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_next_solver_infer_traits.chloro.rs
@@ -29,6 +29,8 @@ use super::InferCtxt;
 /// only live for a short period of time.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ObligationCause {
+    // FIXME: This should contain an `ExprId`/`PatId` etc., and a cause code. But for now we
+    // don't report trait solving diagnostics, so this is irrelevant.
     _private: (),
 }
 

--- a/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_next_solver_infer_traits.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_next_solver_infer_traits.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 8087 bytes
-Chloro size:   7988 bytes
+Chloro size:   8151 bytes
 Rustfmt size:  8281 bytes
 
 ✗ Outputs DIFFER
@@ -24,14 +24,6 @@ Rustfmt size:  8281 bytes
  use super::InferCtxt;
  
  /// The reason why we incurred this obligation; used for error reporting.
- /// only live for a short period of time.
- #[derive(Clone, Debug, PartialEq, Eq)]
- pub struct ObligationCause {
--    // FIXME: This should contain an `ExprId`/`PatId` etc., and a cause code. But for now we
--    // don't report trait solving diagnostics, so this is irrelevant.
-     _private: (),
- }
- 
  /// scope. The eventual result is usually a `Selection` (defined below).
  #[derive(Clone, Debug, TypeVisitable, TypeFoldable)]
  pub struct Obligation<'db, T> {

--- a/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_next_solver_infer_type_variable.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_next_solver_infer_type_variable.chloro.rs
@@ -305,6 +305,7 @@ impl<'db> TypeVariableTable<'_, 'db> {
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub(crate) struct TyVidEqKey<'db> {
     vid: TyVid,
+    // in the table, we map each ty-vid to one of these:
     phantom: PhantomData<TypeVariableValue<'db>>,
 }
 

--- a/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_next_solver_infer_type_variable.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_next_solver_infer_type_variable.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 14353 bytes
-Chloro size:   14231 bytes
+Chloro size:   14288 bytes
 Rustfmt size:  14730 bytes
 
 ✗ Outputs DIFFER
@@ -127,7 +127,7 @@ Rustfmt size:  14730 bytes
  pub(crate) struct TyVidEqKey<'db> {
      vid: TyVid,
 -
--    // in the table, we map each ty-vid to one of these:
+     // in the table, we map each ty-vid to one of these:
      phantom: PhantomData<TypeVariableValue<'db>>,
  }
  

--- a/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_next_solver_region.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_next_solver_region.chloro.rs
@@ -141,6 +141,7 @@ pub type PlaceholderRegion = Placeholder<BoundRegion>;
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub struct EarlyParamRegion {
+    // FIXME: See `ParamTy`.
     pub id: LifetimeParamId,
     pub index: u32,
 }
@@ -169,11 +170,13 @@ impl std::fmt::Debug for LateParamRegion {
 pub enum BoundRegionKind {
     /// An anonymous region parameter for a given fn (&T)
     Anon,
+
     /// Named region parameters for functions (a in &'a T)
     ///
     /// The `DefId` is needed to distinguish free regions in
     /// the event of shadowing.
     Named(SolverDefId),
+
     /// Anonymous region for the implicit env pointer parameter
     /// to a closure
     ClosureEnv,

--- a/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_next_solver_region.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_next_solver_region.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 11497 bytes
-Chloro size:   11469 bytes
+Chloro size:   11500 bytes
 Rustfmt size:  11829 bytes
 
 ✗ Outputs DIFFER
@@ -26,11 +26,6 @@ Rustfmt size:  11829 bytes
      }
  
      pub fn is_placeholder(&self) -> bool {
- 
- #[derive(Copy, Clone, PartialEq, Eq, Hash)]
- pub struct EarlyParamRegion {
--    // FIXME: See `ParamTy`.
-     pub id: LifetimeParamId,
      pub index: u32,
  }
  
@@ -45,19 +40,6 @@ Rustfmt size:  11829 bytes
  pub struct LateParamRegion {
      pub scope: SolverDefId,
      pub bound_region: BoundRegionKind,
- pub enum BoundRegionKind {
-     /// An anonymous region parameter for a given fn (&T)
-     Anon,
--
-     /// Named region parameters for functions (a in &'a T)
-     ///
-     /// The `DefId` is needed to distinguish free regions in
-     /// the event of shadowing.
-     Named(SolverDefId),
--
-     /// Anonymous region for the implicit env pointer parameter
-     /// to a closure
-     ClosureEnv,
      ) -> Result<Self, F::Error> {
          folder.try_fold_region(self)
      }

--- a/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_next_solver_ty.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_next_solver_ty.chloro.rs
@@ -1231,6 +1231,9 @@ pub type PlaceholderTy = Placeholder<BoundTy>;
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub struct ParamTy {
+    // FIXME: I'm not pleased with this. Ideally a `Param` should only know its index - the defining item
+    // is known from the `EarlyBinder`. This should also be beneficial for memory usage. But code currently
+    // assumes it can get the definition from `Param` alone - so that's what we got.
     pub id: TypeParamId,
     pub index: u32,
 }
@@ -1250,6 +1253,7 @@ impl std::fmt::Debug for ParamTy {
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub struct BoundTy {
     pub var: BoundVar,
+    // FIXME: This is for diagnostics in rustc, do we really need it?
     pub kind: BoundTyKind,
 }
 

--- a/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_next_solver_ty.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_next_solver_ty.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 51306 bytes
-Chloro size:   50927 bytes
+Chloro size:   51296 bytes
 Rustfmt size:  52438 bytes
 
 ✗ Outputs DIFFER
@@ -355,22 +355,6 @@ Rustfmt size:  52438 bytes
  impl<'db> Tys<'db> {
      pub fn inputs(&self) -> &[Ty<'db>] {
          self.as_slice().split_last().unwrap().1
- 
- #[derive(Copy, Clone, PartialEq, Eq, Hash)]
- pub struct ParamTy {
--    // FIXME: I'm not pleased with this. Ideally a `Param` should only know its index - the defining item
--    // is known from the `EarlyBinder`. This should also be beneficial for memory usage. But code currently
--    // assumes it can get the definition from `Param` alone - so that's what we got.
-     pub id: TypeParamId,
-     pub index: u32,
- }
- #[derive(Copy, Clone, PartialEq, Eq, Hash)]
- pub struct BoundTy {
-     pub var: BoundVar,
--    // FIXME: This is for diagnostics in rustc, do we really need it?
-     pub kind: BoundTyKind,
- }
- 
      ) -> Result<Self, F::Error> {
          Ok(self)
      }

--- a/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_traits.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_traits.chloro.rs
@@ -33,6 +33,7 @@ use crate::{
 pub struct TraitEnvironment<'db> {
     pub krate: Crate,
     pub block: Option<BlockId>,
+    // FIXME make this a BTreeMap
     traits_from_clauses: Box<[(Ty<'db>, TraitId)]>,
     pub env: ParamEnv<'db>,
 }
@@ -146,9 +147,12 @@ pub fn next_trait_solve_in_ctxt<'db, 'a>(
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum FnTrait {
+    // Warning: Order is important. If something implements `x` it should also implement
+    // `y` if `y <= x`.
     FnOnce,
     FnMut,
     Fn,
+
     AsyncFnOnce,
     AsyncFnMut,
     AsyncFn,

--- a/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_traits.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_traits.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 8324 bytes
-Chloro size:   8103 bytes
+Chloro size:   8251 bytes
 Rustfmt size:  8412 bytes
 
 ✗ Outputs DIFFER
@@ -32,13 +32,6 @@ Rustfmt size:  8412 bytes
      },
  };
  
- pub struct TraitEnvironment<'db> {
-     pub krate: Crate,
-     pub block: Option<BlockId>,
--    // FIXME make this a BTreeMap
-     traits_from_clauses: Box<[(Ty<'db>, TraitId)]>,
-     pub env: ParamEnv<'db>,
- }
          traits_from_clauses: Box<[(Ty<'db>, TraitId)]>,
          env: ParamEnv<'db>,
      ) -> Arc<Self> {
@@ -70,15 +63,3 @@ Rustfmt size:  8412 bytes
      ty.replace_infer_with_error(infcx.interner)
  }
  
- 
- #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
- pub enum FnTrait {
--    // Warning: Order is important. If something implements `x` it should also implement
--    // `y` if `y <= x`.
-     FnOnce,
-     FnMut,
-     Fn,
--
-     AsyncFnOnce,
-     AsyncFnMut,
-     AsyncFn,

--- a/chloro-core/tests/conformance/snapshots/ra/ide/src_folding_ranges.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/ide/src_folding_ranges.chloro.rs
@@ -24,12 +24,12 @@ pub enum FoldKind {
     ReturnType,
     MatchArm,
     Function,
+    // region: item runs
     Modules,
     Consts,
     Statics,
     TypeAliases,
     ExternCrates,
-    // endregion: item runs
 }
 
 #[derive(Debug)]

--- a/chloro-core/tests/conformance/snapshots/ra/ide/src_folding_ranges.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/ide/src_folding_ranges.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 18809 bytes
-Chloro size:   18582 bytes
+Chloro size:   18579 bytes
 Rustfmt size:  18809 bytes
 
 ✗ Outputs DIFFER
@@ -32,13 +32,13 @@ Rustfmt size:  18809 bytes
  const REGION_END: &str = "// endregion";
  
  #[derive(Debug, PartialEq, Eq)]
-     ReturnType,
-     MatchArm,
-     Function,
--    // region: item runs
-     Modules,
-     Consts,
      Statics,
+     TypeAliases,
+     ExternCrates,
+-    // endregion: item runs
+ }
+ 
+ #[derive(Debug)]
      pub kind: FoldKind,
  }
  

--- a/chloro-core/tests/conformance/snapshots/ra/ide/src_highlight_related.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/ide/src_highlight_related.chloro.rs
@@ -23,6 +23,9 @@ use crate::{NavigationTarget, TryToNav, goto_definition, navigation_target::ToNa
 #[derive(PartialEq, Eq, Hash)]
 pub struct HighlightedRange {
     pub range: TextRange,
+    // FIXME: This needs to be more precise. Reference category makes sense only
+    // for references, but we also have defs. And things like exit points are
+    // neither.
     pub category: ReferenceCategory,
 }
 

--- a/chloro-core/tests/conformance/snapshots/ra/ide/src_highlight_related.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/ide/src_highlight_related.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 58223 bytes
-Chloro size:   57069 bytes
+Chloro size:   57244 bytes
 Rustfmt size:  58223 bytes
 
 ✗ Outputs DIFFER
@@ -33,15 +33,6 @@ Rustfmt size:  58223 bytes
  };
  
  use crate::{NavigationTarget, TryToNav, goto_definition, navigation_target::ToNav};
- #[derive(PartialEq, Eq, Hash)]
- pub struct HighlightedRange {
-     pub range: TextRange,
--    // FIXME: This needs to be more precise. Reference category makes sense only
--    // for references, but we also have defs. And things like exit points are
--    // neither.
-     pub category: ReferenceCategory,
- }
- 
  
  type HighlightMap = FxHashMap<EditionedFileId, FxHashSet<HighlightedRange>>;
  

--- a/chloro-core/tests/conformance/snapshots/ra/ide/src_syntax_highlighting_tags.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/ide/src_syntax_highlighting_tags.chloro.rs
@@ -20,6 +20,7 @@ pub struct HlMods(u32);
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum HlTag {
     Symbol(SymbolKind),
+
     AttributeBracket,
     BoolLiteral,
     BuiltinType,
@@ -35,6 +36,8 @@ pub enum HlTag {
     Punctuation(HlPunct),
     StringLiteral,
     UnresolvedReference,
+
+    // For things which don't have a specific highlight.
     None,
 }
 
@@ -84,6 +87,7 @@ pub enum HlMod {
     Static,
     /// Used for items in traits and trait impls.
     Trait,
+    // Keep this last!
     /// Used for unsafe functions, unsafe traits, mutable statics, union accesses and unsafe operations.
     Unsafe,
 }

--- a/chloro-core/tests/conformance/snapshots/ra/ide/src_syntax_highlighting_tags.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/ide/src_syntax_highlighting_tags.diff
@@ -2,24 +2,12 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 10817 bytes
-Chloro size:   10479 bytes
+Chloro size:   10561 bytes
 Rustfmt size:  10923 bytes
 
 ✗ Outputs DIFFER
 
 === DIFF (- rustfmt, + chloro) ===
- #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
- pub enum HlTag {
-     Symbol(SymbolKind),
--
-     AttributeBracket,
-     BoolLiteral,
-     BuiltinType,
-     Punctuation(HlPunct),
-     StringLiteral,
-     UnresolvedReference,
--
--    // For things which don't have a specific highlight.
      None,
  }
  
@@ -34,13 +22,6 @@ Rustfmt size:  10923 bytes
      /// Used with keywords like `async` and `await`.
      Async,
      /// Used to differentiate individual elements within attribute calls.
-     Static,
-     /// Used for items in traits and trait impls.
-     Trait,
--    // Keep this last!
-     /// Used for unsafe functions, unsafe traits, mutable statics, union accesses and unsafe operations.
-     Unsafe,
- }
      }
  
      fn mask(self) -> u32 {

--- a/chloro-core/tests/conformance/snapshots/ra/ide_assists/src_assist_context.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/ide_assists/src_assist_context.chloro.rs
@@ -50,7 +50,9 @@ pub(crate) struct AssistContext<'a> {
     frange: FileRange,
     trimmed_range: TextRange,
     source_file: SourceFile,
+    // We cache this here to speed up things slightly
     token_at_offset: TokenAtOffset<SyntaxToken>,
+    // We cache this here to speed up things slightly
     covering_element: SyntaxElement,
 }
 

--- a/chloro-core/tests/conformance/snapshots/ra/ide_assists/src_assist_context.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/ide_assists/src_assist_context.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 8527 bytes
-Chloro size:   8383 bytes
+Chloro size:   8491 bytes
 Rustfmt size:  8697 bytes
 
 ✗ Outputs DIFFER
@@ -29,15 +29,6 @@ Rustfmt size:  8697 bytes
  /// `AssistContext` allows to apply an assist or check if it could be applied.
  ///
  /// Assists use a somewhat over-engineered approach, given the current needs.
-     frange: FileRange,
-     trimmed_range: TextRange,
-     source_file: SourceFile,
--    // We cache this here to speed up things slightly
-     token_at_offset: TokenAtOffset<SyntaxToken>,
--    // We cache this here to speed up things slightly
-     covering_element: SyntaxElement,
- }
- 
          let end = frange.range.end();
          let left = source_file.syntax().token_at_offset(start);
          let right = source_file.syntax().token_at_offset(end);

--- a/chloro-core/tests/conformance/snapshots/ra/ide_assists/src_handlers_expand_glob_import.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/ide_assists/src_handlers_expand_glob_import.chloro.rs
@@ -196,6 +196,7 @@ fn def_is_referenced_in(def: Definition, ctx: &AssistContext<'_>) -> bool {
 
 #[derive(Debug, Clone)]
 struct Ref {
+    // could be alias
     visible_name: Name,
     def: Definition,
     is_pub: bool,

--- a/chloro-core/tests/conformance/snapshots/ra/ide_assists/src_handlers_expand_glob_import.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/ide_assists/src_handlers_expand_glob_import.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 23406 bytes
-Chloro size:   22499 bytes
+Chloro size:   22521 bytes
 Rustfmt size:  23406 bytes
 
 ✗ Outputs DIFFER
@@ -77,13 +77,6 @@ Rustfmt size:  23406 bytes
  pub(crate) fn expand_glob_reexport(acc: &mut Assists, ctx: &AssistContext<'_>) -> Option<()> {
      let star = ctx.find_token_syntax_at_offset(T![*])?;
      let use_tree = star.parent().and_then(ast::UseTree::cast)?;
- 
- #[derive(Debug, Clone)]
- struct Ref {
--    // could be alias
-     visible_name: Name,
-     def: Definition,
-     is_pub: bool,
      }
  }
  

--- a/chloro-core/tests/conformance/snapshots/ra/ide_assists/src_handlers_flip_binexpr.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/ide_assists/src_handlers_flip_binexpr.chloro.rs
@@ -47,8 +47,11 @@ pub(crate) fn flip_binexpr(acc: &mut Assists, ctx: &AssistContext<'_>) -> Option
 }
 
 enum FlipAction {
+    // Flip the expression
     Flip,
+    // Flip the expression and replace the operator with this string
     FlipAndReplaceOp(SyntaxKind),
+    // Do not flip the expression
     DontFlip,
 }
 

--- a/chloro-core/tests/conformance/snapshots/ra/ide_assists/src_handlers_flip_binexpr.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/ide_assists/src_handlers_flip_binexpr.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 6743 bytes
-Chloro size:   6090 bytes
+Chloro size:   6220 bytes
 Rustfmt size:  6902 bytes
 
 ✗ Outputs DIFFER
@@ -39,17 +39,6 @@ Rustfmt size:  6902 bytes
      if !cursor_in_range {
          return None;
      }
- }
- 
- enum FlipAction {
--    // Flip the expression
-     Flip,
--    // Flip the expression and replace the operator with this string
-     FlipAndReplaceOp(SyntaxKind),
--    // Do not flip the expression
-     DontFlip,
- }
- 
      }
  }
  

--- a/chloro-core/tests/conformance/snapshots/ra/ide_assists/src_handlers_generate_function.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/ide_assists/src_handlers_generate_function.chloro.rs
@@ -1266,6 +1266,7 @@ impl Graph {
 struct Visitor<'g> {
     graph: &'g Graph,
     visited: Vec<bool>,
+    // Stack is held in this struct so we can reuse its buffer.
     stack: Vec<usize>,
 }
 

--- a/chloro-core/tests/conformance/snapshots/ra/ide_assists/src_handlers_generate_function.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/ide_assists/src_handlers_generate_function.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 75023 bytes
-Chloro size:   74309 bytes
+Chloro size:   74373 bytes
 Rustfmt size:  75023 bytes
 
 ✗ Outputs DIFFER
@@ -125,13 +125,6 @@ Rustfmt size:  75023 bytes
  /// Minimally implemented directed graph structure represented by adjacency list.
  struct Graph {
      edges: Vec<Vec<usize>>,
- struct Visitor<'g> {
-     graph: &'g Graph,
-     visited: Vec<bool>,
--    // Stack is held in this struct so we can reuse its buffer.
-     stack: Vec<usize>,
- }
- 
  #[cfg(test)]
  mod tests {
      use crate::tests::{check_assist, check_assist_not_applicable};

--- a/chloro-core/tests/conformance/snapshots/ra/ide_assists/src_utils.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/ide_assists/src_utils.chloro.rs
@@ -800,11 +800,17 @@ pub(crate) struct ReferenceConversion<'db> {
 
 #[derive(Debug)]
 enum ReferenceConversionType {
+    // reference can be stripped if the type is Copy
     Copy,
+    // &String -> &str
     AsRefStr,
+    // &Vec<T> -> &[T]
     AsRefSlice,
+    // &Box<T> -> &T
     Dereferenced,
+    // &Option<T> -> Option<&T>
     Option,
+    // &Result<T, E> -> Result<&T, &E>
     Result,
 }
 

--- a/chloro-core/tests/conformance/snapshots/ra/ide_assists/src_utils.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/ide_assists/src_utils.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 45288 bytes
-Chloro size:   44475 bytes
+Chloro size:   44666 bytes
 Rustfmt size:  45288 bytes
 
 ✗ Outputs DIFFER
@@ -143,23 +143,6 @@ Rustfmt size:  45288 bytes
 +    trait_: ast::Type,
 +) -> ast::Impl {
      generate_impl_inner(is_unsafe, adt, Some(trait_), true, None)
- }
- 
- 
- #[derive(Debug)]
- enum ReferenceConversionType {
--    // reference can be stripped if the type is Copy
-     Copy,
--    // &String -> &str
-     AsRefStr,
--    // &Vec<T> -> &[T]
-     AsRefSlice,
--    // &Box<T> -> &T
-     Dereferenced,
--    // &Option<T> -> Option<&T>
-     Option,
--    // &Result<T, E> -> Result<&T, &E>
-     Result,
  }
  
      }

--- a/chloro-core/tests/conformance/snapshots/ra/ide_completion/src_context.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/ide_completion/src_context.chloro.rs
@@ -47,6 +47,7 @@ pub(crate) enum Visible {
 /// Existing qualifiers for the thing we are currently completing.
 #[derive(Debug, Default)]
 pub(crate) struct QualifierCtx {
+    // TODO: Add try_tok and default_tok
     pub(crate) async_tok: Option<SyntaxToken>,
     pub(crate) unsafe_tok: Option<SyntaxToken>,
     pub(crate) safe_tok: Option<SyntaxToken>,
@@ -455,6 +456,7 @@ pub(crate) struct CompletionContext<'a> {
     pub(crate) containing_function: Option<hir::Function>,
     /// Whether nightly toolchain is used. Cached since this is looked up a lot.
     pub(crate) is_nightly: bool,
+    // FIXME: This should probably be the crate of the current token?
     /// The edition of the current crate
     pub(crate) edition: Edition,
     /// The expected name of what we are completing.

--- a/chloro-core/tests/conformance/snapshots/ra/ide_completion/src_context.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/ide_completion/src_context.diff
@@ -2,19 +2,12 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 30787 bytes
-Chloro size:   30669 bytes
+Chloro size:   30780 bytes
 Rustfmt size:  31005 bytes
 
 ✗ Outputs DIFFER
 
 === DIFF (- rustfmt, + chloro) ===
- /// Existing qualifiers for the thing we are currently completing.
- #[derive(Debug, Default)]
- pub(crate) struct QualifierCtx {
--    // TODO: Add try_tok and default_tok
-     pub(crate) async_tok: Option<SyntaxToken>,
-     pub(crate) unsafe_tok: Option<SyntaxToken>,
-     pub(crate) safe_tok: Option<SyntaxToken>,
      pub(crate) qualified: Qualified<'db>,
      /// The parent of the path we are completing.
      pub(crate) parent: Option<ast::Path>,
@@ -52,10 +45,12 @@ Rustfmt size:  31005 bytes
      pub(crate) trigger_character: Option<char>,
      /// The token before the cursor, in the original file.
      pub(crate) original_token: SyntaxToken,
+     pub(crate) containing_function: Option<hir::Function>,
      /// Whether nightly toolchain is used. Cached since this is looked up a lot.
      pub(crate) is_nightly: bool,
-     /// The edition of the current crate
--    // FIXME: This should probably be the crate of the current token?
+-    /// The edition of the current crate
+     // FIXME: This should probably be the crate of the current token?
++    /// The edition of the current crate
      pub(crate) edition: Edition,
 -
      /// The expected name of what we are completing.

--- a/chloro-core/tests/conformance/snapshots/ra/ide_completion/src_item.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/ide_completion/src_item.chloro.rs
@@ -67,6 +67,9 @@ pub struct CompletionItem {
     /// all possible items, and then separately build an ordered completion list
     /// based on relevance and fuzzy matching with the already typed identifier.
     pub relevance: CompletionRelevance,
+    // FIXME: We shouldn't expose Mutability here (that is HIR types at all), its fine for now though
+    // until we have more splitting completions in which case we should think about
+    // generalizing this. See https://github.com/rust-lang/rust-analyzer/issues/12571
     /// Indicates that a reference or mutable reference to this variable is a
     /// possible match.
     pub ref_match: Option<(CompletionItemRefMode, TextSize)>,

--- a/chloro-core/tests/conformance/snapshots/ra/ide_completion/src_item.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/ide_completion/src_item.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 27860 bytes
-Chloro size:   27468 bytes
+Chloro size:   27740 bytes
 Rustfmt size:  27860 bytes
 
 ✗ Outputs DIFFER
@@ -65,11 +65,13 @@ Rustfmt size:  27860 bytes
      /// based on relevance and fuzzy matching with the already typed identifier.
      pub relevance: CompletionRelevance,
 -
-     /// Indicates that a reference or mutable reference to this variable is a
-     /// possible match.
--    // FIXME: We shouldn't expose Mutability here (that is HIR types at all), its fine for now though
--    // until we have more splitting completions in which case we should think about
--    // generalizing this. See https://github.com/rust-lang/rust-analyzer/issues/12571
+-    /// Indicates that a reference or mutable reference to this variable is a
+-    /// possible match.
+     // FIXME: We shouldn't expose Mutability here (that is HIR types at all), its fine for now though
+     // until we have more splitting completions in which case we should think about
+     // generalizing this. See https://github.com/rust-lang/rust-analyzer/issues/12571
++    /// Indicates that a reference or mutable reference to this variable is a
++    /// possible match.
      pub ref_match: Option<(CompletionItemRefMode, TextSize)>,
 -
      /// The import data to add to completion's edits.

--- a/chloro-core/tests/conformance/snapshots/ra/ide_db/src_assists.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/ide_db/src_assists.chloro.rs
@@ -147,6 +147,7 @@ pub enum AssistResolveStrategy {
 pub struct SingleResolve {
     /// The id of the assist.
     pub assist_id: String,
+    // The kind of the assist.
     pub assist_kind: AssistKind,
     /// Subtype of the assist. When many assists have the same id, it differentiates among them.
     pub assist_subtype: Option<usize>,

--- a/chloro-core/tests/conformance/snapshots/ra/ide_db/src_assists.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/ide_db/src_assists.diff
@@ -2,16 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 5963 bytes
-Chloro size:   5932 bytes
+Chloro size:   5963 bytes
 Rustfmt size:  5963 bytes
 
-✗ Outputs DIFFER
-
-=== DIFF (- rustfmt, + chloro) ===
- pub struct SingleResolve {
-     /// The id of the assist.
-     pub assist_id: String,
--    // The kind of the assist.
-     pub assist_kind: AssistKind,
-     /// Subtype of the assist. When many assists have the same id, it differentiates among them.
-     pub assist_subtype: Option<usize>,
+✓ Outputs are IDENTICAL

--- a/chloro-core/tests/conformance/snapshots/ra/ide_db/src_documentation.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/ide_db/src_documentation.chloro.rs
@@ -50,6 +50,9 @@ pub trait HasDocs {
 #[derive(Debug)]
 pub struct DocsRangeMap {
     source_map: AttrSourceMap,
+    // (docstring-line-range, attr_index, attr-string-range)
+    // a mapping from the text range of a line of the [`Documentation`] to the attribute index and
+    // the original (untrimmed) syntax doc line
     mapping: Vec<(TextRange, AttrId, TextRange)>,
 }
 

--- a/chloro-core/tests/conformance/snapshots/ra/ide_db/src_documentation.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/ide_db/src_documentation.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 11810 bytes
-Chloro size:   11424 bytes
+Chloro size:   11632 bytes
 Rustfmt size:  12398 bytes
 
 ✗ Outputs DIFFER
@@ -32,13 +32,6 @@ Rustfmt size:  12398 bytes
  /// A struct to map text ranges from [`Documentation`] back to TextRanges in the syntax tree.
  #[derive(Debug)]
  pub struct DocsRangeMap {
-     source_map: AttrSourceMap,
--    // (docstring-line-range, attr_index, attr-string-range)
--    // a mapping from the text range of a line of the [`Documentation`] to the attribute index and
--    // the original (untrimmed) syntax doc line
-     mapping: Vec<(TextRange, AttrId, TextRange)>,
- }
- 
  impl DocsRangeMap {
      /// Maps a [`TextRange`] relative to the documentation string back to its AST range
      pub fn map(&self, range: TextRange) -> Option<(InFile<TextRange>, AttrId)> {

--- a/chloro-core/tests/conformance/snapshots/ra/ide_db/src_imports_insert_use.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/ide_db/src_imports_insert_use.chloro.rs
@@ -247,6 +247,7 @@ pub fn remove_path_if_in_use_stmt(path: &ast::Path) {
 
 #[derive(Eq, PartialEq, PartialOrd, Ord)]
 enum ImportGroup {
+    // the order here defines the order of new group inserts
     Std,
     ExternCrate,
     ThisCrate,

--- a/chloro-core/tests/conformance/snapshots/ra/ide_db/src_imports_insert_use.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/ide_db/src_imports_insert_use.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 20506 bytes
-Chloro size:   20445 bytes
+Chloro size:   20506 bytes
 Rustfmt size:  20506 bytes
 
 ✗ Outputs DIFFER
@@ -46,10 +46,3 @@ Rustfmt size:  20506 bytes
  /// How imports should be grouped into use statements.
  #[derive(Copy, Clone, Debug, PartialEq, Eq)]
  pub enum ImportGranularity {
- 
- #[derive(Eq, PartialEq, PartialOrd, Ord)]
- enum ImportGroup {
--    // the order here defines the order of new group inserts
-     Std,
-     ExternCrate,
-     ThisCrate,

--- a/chloro-core/tests/conformance/snapshots/ra/ide_db/src_lib.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/ide_db/src_lib.chloro.rs
@@ -72,6 +72,12 @@ pub type FileRange = FileRangeWrapper<FileId>;
 
 #[salsa_macros::db]
 pub struct RootDatabase {
+    // FIXME: Revisit this commit now that we migrated to the new salsa, given we store arcs in this
+    // db directly now
+    // We use `ManuallyDrop` here because every codegen unit that contains a
+    // `&RootDatabase -> &dyn OtherDatabase` cast will instantiate its drop glue in the vtable,
+    // which duplicates `Weak::drop` and `Arc::drop` tens of thousands of times, which makes
+    // compile times of all `ide_*` and downstream crates suffer greatly.
     storage: ManuallyDrop<salsa::Storage<Self>>,
     files: Arc<Files>,
     crates_map: Arc<CratesMap>,

--- a/chloro-core/tests/conformance/snapshots/ra/ide_db/src_lib.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/ide_db/src_lib.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 12405 bytes
-Chloro size:   11797 bytes
+Chloro size:   12261 bytes
 Rustfmt size:  12539 bytes
 
 ✗ Outputs DIFFER
@@ -81,16 +81,6 @@ Rustfmt size:  12539 bytes
  pub type FileRange = FileRangeWrapper<FileId>;
  
  #[salsa_macros::db]
- pub struct RootDatabase {
--    // FIXME: Revisit this commit now that we migrated to the new salsa, given we store arcs in this
--    // db directly now
--    // We use `ManuallyDrop` here because every codegen unit that contains a
--    // `&RootDatabase -> &dyn OtherDatabase` cast will instantiate its drop glue in the vtable,
--    // which duplicates `Weak::drop` and `Arc::drop` tens of thousands of times, which makes
--    // compile times of all `ide_*` and downstream crates suffer greatly.
-     storage: ManuallyDrop<salsa::Storage<Self>>,
-     files: Arc<Files>,
-     crates_map: Arc<CratesMap>,
      nonce: Nonce,
  }
  

--- a/chloro-core/tests/conformance/snapshots/ra/ide_db/src_path_transform.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/ide_db/src_path_transform.chloro.rs
@@ -25,6 +25,7 @@ struct AstSubsts {
 #[derive(Debug)]
 enum TypeOrConst {
     Either(ast::TypeArg),
+    // indistinguishable type or const param
     Const(ast::ConstArg),
 }
 

--- a/chloro-core/tests/conformance/snapshots/ra/ide_db/src_path_transform.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/ide_db/src_path_transform.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 25826 bytes
-Chloro size:   25632 bytes
+Chloro size:   25677 bytes
 Rustfmt size:  25826 bytes
 
 ✗ Outputs DIFFER
@@ -39,6 +39,7 @@ Rustfmt size:  25826 bytes
  enum TypeOrConst {
 -    Either(ast::TypeArg), // indistinguishable type or const param
 +    Either(ast::TypeArg),
++    // indistinguishable type or const param
      Const(ast::ConstArg),
  }
  

--- a/chloro-core/tests/conformance/snapshots/ra/ide_db/src_ra_fixture.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/ide_db/src_ra_fixture.chloro.rs
@@ -62,6 +62,7 @@ pub struct RaFixtureAnalysis {
     virtual_file_id_to_line: Vec<usize>,
     mapper: RangeMapper,
     literal: ast::String,
+    // `minicore` etc..
     sysroot_files: Vec<FileId>,
     combined_len: TextSize,
 }

--- a/chloro-core/tests/conformance/snapshots/ra/ide_db/src_ra_fixture.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/ide_db/src_ra_fixture.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 18130 bytes
-Chloro size:   17708 bytes
+Chloro size:   17732 bytes
 Rustfmt size:  18477 bytes
 
 ✗ Outputs DIFFER
@@ -26,13 +26,6 @@ Rustfmt size:  18477 bytes
  impl RootDatabase {
      fn from_ra_fixture(
          text: &str,
-     virtual_file_id_to_line: Vec<usize>,
-     mapper: RangeMapper,
-     literal: ast::String,
--    // `minicore` etc..
-     sysroot_files: Vec<FileId>,
-     combined_len: TextSize,
- }
          let mut mapper = RangeMapper::default();
  
          // This is used for the `Injector`, to resolve precise location in the string literal,

--- a/chloro-core/tests/conformance/snapshots/ra/ide_db/src_syntax_helpers_tree_diff.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/ide_db/src_syntax_helpers_tree_diff.chloro.rs
@@ -15,6 +15,7 @@ enum TreeDiffInsertPos {
 pub struct TreeDiff {
     replacements: FxHashMap<SyntaxElement, SyntaxElement>,
     deletions: Vec<SyntaxElement>,
+    // the vec as well as the indexmap are both here to preserve order
     insertions: FxIndexMap<TreeDiffInsertPos, Vec<SyntaxElement>>,
 }
 

--- a/chloro-core/tests/conformance/snapshots/ra/ide_db/src_syntax_helpers_tree_diff.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/ide_db/src_syntax_helpers_tree_diff.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 14963 bytes
-Chloro size:   14880 bytes
+Chloro size:   14951 bytes
 Rustfmt size:  15195 bytes
 
 ✗ Outputs DIFFER
@@ -18,13 +18,6 @@ Rustfmt size:  15195 bytes
  
  #[derive(Debug, Hash, PartialEq, Eq)]
  enum TreeDiffInsertPos {
- pub struct TreeDiff {
-     replacements: FxHashMap<SyntaxElement, SyntaxElement>,
-     deletions: Vec<SyntaxElement>,
--    // the vec as well as the indexmap are both here to preserve order
-     insertions: FxIndexMap<TreeDiffInsertPos, Vec<SyntaxElement>>,
- }
- 
                  TreeDiffInsertPos::After(it) => it.text_range().end(),
                  TreeDiffInsertPos::AsFirstChild(it) => it.text_range().start(),
              };

--- a/chloro-core/tests/conformance/snapshots/ra/ide_diagnostics/src_lib.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/ide_diagnostics/src_lib.chloro.rs
@@ -153,6 +153,7 @@ pub struct Diagnostic {
     pub unused: bool,
     pub experimental: bool,
     pub fixes: Option<Vec<Assist>>,
+    // The node that will be affected by `#[allow]` and similar attributes.
     pub main_node: Option<InFile<SyntaxNodePtr>>,
 }
 
@@ -224,6 +225,7 @@ pub struct DiagnosticsConfig {
     pub disabled: FxHashSet<String>,
     pub expr_fill_default: ExprFillDefaultMode,
     pub style_lints: bool,
+    // FIXME: We may want to include a whole `AssistConfig` here
     pub snippet_cap: Option<SnippetCap>,
     pub insert_use: InsertUseConfig,
     pub prefer_no_std: bool,

--- a/chloro-core/tests/conformance/snapshots/ra/ide_diagnostics/src_lib.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/ide_diagnostics/src_lib.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 33895 bytes
-Chloro size:   33582 bytes
+Chloro size:   33723 bytes
 Rustfmt size:  33895 bytes
 
 ✗ Outputs DIFFER
@@ -79,20 +79,6 @@ Rustfmt size:  33895 bytes
  #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
  pub enum DiagnosticCode {
      RustcHardError(&'static str),
-     pub unused: bool,
-     pub experimental: bool,
-     pub fixes: Option<Vec<Assist>>,
--    // The node that will be affected by `#[allow]` and similar attributes.
-     pub main_node: Option<InFile<SyntaxNodePtr>>,
- }
- 
-     pub disabled: FxHashSet<String>,
-     pub expr_fill_default: ExprFillDefaultMode,
-     pub style_lints: bool,
--    // FIXME: We may want to include a whole `AssistConfig` here
-     pub snippet_cap: Option<SnippetCap>,
-     pub insert_use: InsertUseConfig,
-     pub prefer_no_std: bool,
      let parse = sema.parse(editioned_file_id);
  
      // FIXME: This iterates the entire file which is a rather expensive operation.

--- a/chloro-core/tests/conformance/snapshots/ra/rust_analyzer/src_config.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/rust_analyzer/src_config.chloro.rs
@@ -1044,15 +1044,21 @@ pub struct CallInfoConfig {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct LensConfig {
+    // runnables
     pub run: bool,
     pub debug: bool,
     pub update_test: bool,
     pub interpret: bool,
+    // implementations
     pub implementations: bool,
+    // references
     pub method_refs: bool,
     pub refs_adt: bool,
+    // for Struct, Enum, Union and Trait
     pub refs_trait: bool,
+    // for Struct, Enum, Union and Trait
     pub enum_variant_refs: bool,
+    // annotations
     pub location: AnnotationLocation,
     pub filter_adjacent_derive_implementations: bool,
 }

--- a/chloro-core/tests/conformance/snapshots/ra/rust_analyzer/src_config.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/rust_analyzer/src_config.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 167117 bytes
-Chloro size:   149968 bytes
+Chloro size:   150127 bytes
 Rustfmt size:  167117 bytes
 
 ✗ Outputs DIFFER
@@ -1574,30 +1574,26 @@ Rustfmt size:  167117 bytes
          self.user_config_change = content;
      }
  
- 
- #[derive(Clone, Debug, PartialEq, Eq)]
- pub struct LensConfig {
--    // runnables
-     pub run: bool,
      pub debug: bool,
      pub update_test: bool,
      pub interpret: bool,
 -
--    // implementations
+     // implementations
      pub implementations: bool,
 -
--    // references
+     // references
      pub method_refs: bool,
 -    pub refs_adt: bool,   // for Struct, Enum, Union and Trait
 -    pub refs_trait: bool, // for Struct, Enum, Union and Trait
 +    pub refs_adt: bool,
++    // for Struct, Enum, Union and Trait
 +    pub refs_trait: bool,
++    // for Struct, Enum, Union and Trait
      pub enum_variant_refs: bool,
 -
--    // annotations
+     // annotations
      pub location: AnnotationLocation,
      pub filter_adjacent_derive_implementations: bool,
- }
  
  #[derive(Debug, Clone)]
  pub enum RustfmtConfig {

--- a/chloro-core/tests/conformance/snapshots/ra/rust_analyzer/src_diagnostics.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/rust_analyzer/src_diagnostics.chloro.rs
@@ -40,6 +40,7 @@ pub(crate) struct PackageFlycheckDiagnostic {
 
 #[derive(Debug, Default, Clone)]
 pub(crate) struct DiagnosticCollection {
+    // FIXME: should be FxHashMap<FileId, Vec<ra_id::Diagnostic>>
     pub(crate) native_syntax: FxHashMap<FileId, (DiagnosticsGeneration, Vec<lsp_types::Diagnostic>)>,
     pub(crate) native_semantic: FxHashMap<FileId, (DiagnosticsGeneration, Vec<lsp_types::Diagnostic>)>,
     pub(crate) check: Vec<WorkspaceFlycheckDiagnostic>,
@@ -54,6 +55,7 @@ pub(crate) struct DiagnosticCollection {
 
 #[derive(Debug, Clone)]
 pub(crate) struct Fix {
+    // Fixes may be triggerable from multiple ranges.
     pub(crate) ranges: SmallVec<[lsp_types::Range; 1]>,
     pub(crate) action: lsp_ext::CodeAction,
 }

--- a/chloro-core/tests/conformance/snapshots/ra/rust_analyzer/src_diagnostics.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/rust_analyzer/src_diagnostics.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 13221 bytes
-Chloro size:   13083 bytes
+Chloro size:   13203 bytes
 Rustfmt size:  13526 bytes
 
 ✗ Outputs DIFFER
@@ -30,10 +30,9 @@ Rustfmt size:  13526 bytes
  
  #[derive(Debug, Default, Clone)]
  pub struct DiagnosticsMapConfig {
- 
  #[derive(Debug, Default, Clone)]
  pub(crate) struct DiagnosticCollection {
--    // FIXME: should be FxHashMap<FileId, Vec<ra_id::Diagnostic>>
+     // FIXME: should be FxHashMap<FileId, Vec<ra_id::Diagnostic>>
 -    pub(crate) native_syntax:
 -        FxHashMap<FileId, (DiagnosticsGeneration, Vec<lsp_types::Diagnostic>)>,
 -    pub(crate) native_semantic:
@@ -43,13 +42,6 @@ Rustfmt size:  13526 bytes
      pub(crate) check: Vec<WorkspaceFlycheckDiagnostic>,
      pub(crate) check_fixes: CheckFixes,
      changes: FxHashSet<FileId>,
- 
- #[derive(Debug, Clone)]
- pub(crate) struct Fix {
--    // Fixes may be triggerable from multiple ranges.
-     pub(crate) ranges: SmallVec<[lsp_types::Range; 1]>,
-     pub(crate) action: lsp_ext::CodeAction,
- }
          let Some(check) = self.check.get_mut(flycheck_id) else {
              return;
          };

--- a/chloro-core/tests/conformance/snapshots/ra/rust_analyzer/src_discover.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/rust_analyzer/src_discover.chloro.rs
@@ -78,6 +78,7 @@ impl DiscoverCommand {
 #[derive(Debug)]
 pub(crate) struct DiscoverHandle {
     _handle: CommandHandle<DiscoverProjectMessage>,
+    // not accessed, but used to log on drop.
     #[allow(dead_code)]
     span: EnteredSpan,
 }

--- a/chloro-core/tests/conformance/snapshots/ra/rust_analyzer/src_discover.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/rust_analyzer/src_discover.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 5655 bytes
-Chloro size:   5622 bytes
+Chloro size:   5668 bytes
 Rustfmt size:  5830 bytes
 
 ✗ Outputs DIFFER
@@ -28,6 +28,7 @@ Rustfmt size:  5830 bytes
  pub(crate) struct DiscoverHandle {
      _handle: CommandHandle<DiscoverProjectMessage>,
 -    #[allow(dead_code)] // not accessed, but used to log on drop.
++    // not accessed, but used to log on drop.
 +    #[allow(dead_code)]
      span: EnteredSpan,
  }

--- a/chloro-core/tests/conformance/snapshots/ra/rust_analyzer/src_flycheck.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/rust_analyzer/src_flycheck.chloro.rs
@@ -142,6 +142,7 @@ impl fmt::Display for FlycheckConfig {
 /// The spawned thread is shut down when this struct is dropped.
 #[derive(Debug)]
 pub(crate) struct FlycheckHandle {
+    // XXX: drop order is significant
     sender: Sender<StateChange>,
     _thread: stdx::thread::JoinHandle,
     id: usize,
@@ -243,11 +244,13 @@ pub(crate) enum FlycheckMessage {
         diagnostic: Diagnostic,
         package_id: Option<Arc<PackageId>>,
     },
+
     /// Request clearing all outdated diagnostics.
     ClearDiagnostics {
         id: usize,
         kind: ClearDiagnosticsKind,
     },
+
     /// Request check progress notification to client
     Progress {
         /// Flycheck instance ID

--- a/chloro-core/tests/conformance/snapshots/ra/rust_analyzer/src_flycheck.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/rust_analyzer/src_flycheck.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 31299 bytes
-Chloro size:   31320 bytes
+Chloro size:   31360 bytes
 Rustfmt size:  31299 bytes
 
 ✗ Outputs DIFFER
@@ -27,27 +27,17 @@ Rustfmt size:  31299 bytes
  use toolchain::Tool;
  use triomphe::Arc;
  
- /// The spawned thread is shut down when this struct is dropped.
- #[derive(Debug)]
- pub(crate) struct FlycheckHandle {
--    // XXX: drop order is significant
-     sender: Sender<StateChange>,
-     _thread: stdx::thread::JoinHandle,
-     id: usize,
-         diagnostic: Diagnostic,
-         package_id: Option<Arc<PackageId>>,
      },
--
+ 
      /// Request clearing all outdated diagnostics.
 -    ClearDiagnostics { id: usize, kind: ClearDiagnosticsKind },
--
 +    ClearDiagnostics {
 +        id: usize,
 +        kind: ClearDiagnosticsKind,
 +    },
+ 
      /// Request check progress notification to client
      Progress {
-         /// Flycheck instance ID
  
  enum FlycheckScope {
      Workspace,

--- a/chloro-core/tests/conformance/snapshots/ra/rust_analyzer/src_global_state.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/rust_analyzer/src_global_state.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 37899 bytes
-Chloro size:   37196 bytes
+Chloro size:   37855 bytes
 Rustfmt size:  37899 bytes
 
 ✗ Outputs DIFFER
@@ -51,44 +51,40 @@ Rustfmt size:  37899 bytes
      pub(crate) local_roots_parent_map: Arc<FxHashMap<SourceRootId, SourceRootId>>,
      pub(crate) semantic_tokens_cache: Arc<Mutex<FxHashMap<Url, SemanticTokens>>>,
 -
--    // status
+     // status
      pub(crate) shutdown_requested: bool,
      pub(crate) last_reported_status: lsp_ext::ServerStatusParams,
 -
--    // proc macros
+     // proc macros
      pub(crate) proc_macro_clients: Arc<[Option<anyhow::Result<ProcMacroClient>>]>,
      pub(crate) build_deps_changed: bool,
 -
--    // Flycheck
+     // Flycheck
      pub(crate) flycheck: Arc<[FlycheckHandle]>,
      pub(crate) flycheck_sender: Sender<FlycheckMessage>,
      pub(crate) flycheck_receiver: Receiver<FlycheckMessage>,
      pub(crate) last_flycheck_error: Option<String>,
 -
--    // Test explorer
+     // Test explorer
      pub(crate) test_run_session: Option<Vec<CargoTestHandle>>,
      pub(crate) test_run_sender: Sender<CargoTestMessage>,
      pub(crate) test_run_receiver: Receiver<CargoTestMessage>,
      pub(crate) test_run_remaining_jobs: usize,
 -
--    // Project loading
+     // Project loading
      pub(crate) discover_handle: Option<discover::DiscoverHandle>,
      pub(crate) discover_sender: Sender<discover::DiscoverProjectMessage>,
      pub(crate) discover_receiver: Receiver<discover::DiscoverProjectMessage>,
 -
--    // Debouncing channel for fetching the workspace
--    // we want to delay it until the VFS looks stable-ish (and thus is not currently in the middle
--    // of a VCS operation like `git switch`)
+     // Debouncing channel for fetching the workspace
+     // we want to delay it until the VFS looks stable-ish (and thus is not currently in the middle
+     // of a VCS operation like `git switch`)
      pub(crate) fetch_ws_receiver: Option<(Receiver<Instant>, FetchWorkspaceRequest)>,
 -
--    // VFS
+     // VFS
      pub(crate) loader: Handle<Box<dyn vfs::loader::Handle>, Receiver<vfs::loader::Message>>,
      pub(crate) vfs: Arc<RwLock<(vfs::Vfs, FxHashMap<FileId, LineEndings>)>>,
-     pub(crate) vfs_config_version: u32,
-     pub(crate) vfs_progress_config_version: u32,
-     pub(crate) vfs_done: bool,
--    // used to track how long VFS loading takes. this can't be on `vfs::loader::Handle`,
--    // as that handle's lifetime is the same as `GlobalState` itself.
+     // as that handle's lifetime is the same as `GlobalState` itself.
      pub(crate) vfs_span: Option<tracing::span::EnteredSpan>,
      pub(crate) wants_to_switch: Option<Cause>,
 -
@@ -99,7 +95,7 @@ Rustfmt size:  37899 bytes
      pub(crate) crate_graph_file_dependencies: FxHashSet<vfs::VfsPath>,
      pub(crate) detached_files: FxHashSet<ManifestPath>,
 -
--    // op queues
+     // op queues
      pub(crate) fetch_workspaces_queue: OpQueue<FetchWorkspaceRequest, FetchWorkspaceResponse>,
      pub(crate) fetch_build_data_queue: OpQueue<(), FetchBuildDataResponse>,
      pub(crate) fetch_proc_macros_queue: OpQueue<(ChangeWithProcMacros, Vec<ProcMacroPaths>), bool>,
@@ -120,14 +116,6 @@ Rustfmt size:  37899 bytes
  #[derive(Debug, Clone, Default)]
  pub(crate) struct MiniCoreRustAnalyzerInternalOnly {
      pub(crate) minicore_text: Option<String>,
-     pub(crate) semantic_tokens_cache: Arc<Mutex<FxHashMap<Url, SemanticTokens>>>,
-     vfs: Arc<RwLock<(vfs::Vfs, FxHashMap<FileId, LineEndings>)>>,
-     pub(crate) workspaces: Arc<Vec<ProjectWorkspace>>,
--    // used to signal semantic highlighting to fall back to syntax based highlighting until
--    // proc-macros have been loaded
--    // FIXME: Can we derive this from somewhere else?
-     pub(crate) proc_macros_loaded: bool,
-     pub(crate) flycheck: Arc<[FlycheckHandle]>,
      minicore: MiniCoreRustAnalyzerInternalOnly,
  }
  

--- a/chloro-core/tests/conformance/snapshots/ra/rust_analyzer/src_lsp_ext.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/rust_analyzer/src_lsp_ext.chloro.rs
@@ -570,7 +570,9 @@ pub struct CargoRunnableArgs {
     pub override_cargo: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub workspace_root: Option<Utf8PathBuf>,
+    // command, --package and --lib stuff
     pub cargo_args: Vec<String>,
+    // stuff after --
     pub executable_args: Vec<String>,
 }
 
@@ -959,6 +961,7 @@ pub struct CompletionResolveData {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct InlayHintResolveData {
     pub file_id: u32,
+    // This is a string instead of a u64 as javascript can't represent u64 fully
     pub hash: String,
     pub resolve_range: lsp_types::Range,
     #[serde(skip_serializing_if = "Option::is_none", default)]

--- a/chloro-core/tests/conformance/snapshots/ra/rust_analyzer/src_lsp_ext.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/rust_analyzer/src_lsp_ext.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 24042 bytes
-Chloro size:   23895 bytes
+Chloro size:   24040 bytes
 Rustfmt size:  24042 bytes
 
 ✗ Outputs DIFFER
@@ -459,15 +459,6 @@ Rustfmt size:  24042 bytes
      const METHOD: &'static str = "experimental/runnables";
  }
  
-     pub override_cargo: Option<String>,
-     #[serde(skip_serializing_if = "Option::is_none")]
-     pub workspace_root: Option<Utf8PathBuf>,
--    // command, --package and --lib stuff
-     pub cargo_args: Vec<String>,
--    // stuff after --
-     pub executable_args: Vec<String>,
- }
- 
      pub args: Vec<String>,
  }
  
@@ -674,10 +665,3 @@ Rustfmt size:  24042 bytes
      const METHOD: &'static str = "textDocument/onTypeFormatting";
  }
  
- #[derive(Debug, Serialize, Deserialize)]
- pub struct InlayHintResolveData {
-     pub file_id: u32,
--    // This is a string instead of a u64 as javascript can't represent u64 fully
-     pub hash: String,
-     pub resolve_range: lsp_types::Range,
-     #[serde(skip_serializing_if = "Option::is_none", default)]

--- a/chloro-core/tests/conformance/snapshots/ra/rust_analyzer/src_main_loop.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/rust_analyzer/src_main_loop.chloro.rs
@@ -126,6 +126,7 @@ pub(crate) enum Task {
     FetchWorkspace(ProjectWorkspaceProgress),
     FetchBuildData(BuildDataProgress),
     LoadProcMacros(ProcMacroProgress),
+    // FIXME: Remove this in favor of a more general QueuedTask, see `handle_did_save_text_document`
     BuildDepsHaveChanged,
 }
 

--- a/chloro-core/tests/conformance/snapshots/ra/rust_analyzer/src_main_loop.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/rust_analyzer/src_main_loop.diff
@@ -2,7 +2,7 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 58838 bytes
-Chloro size:   58730 bytes
+Chloro size:   58831 bytes
 Rustfmt size:  58838 bytes
 
 ✗ Outputs DIFFER
@@ -59,13 +59,6 @@ Rustfmt size:  58838 bytes
      // https://github.com/rust-lang/rust-analyzer/issues/2835
      #[cfg(windows)]
      unsafe {
-     FetchWorkspace(ProjectWorkspaceProgress),
-     FetchBuildData(BuildDataProgress),
-     LoadProcMacros(ProcMacroProgress),
--    // FIXME: Remove this in favor of a more general QueuedTask, see `handle_did_save_text_document`
-     BuildDepsHaveChanged,
- }
- 
  pub(crate) enum PrimeCachesProgress {
      Begin,
      Report(ide::ParallelPrimeCachesProgress),

--- a/chloro-core/tests/conformance/snapshots/ra/rust_analyzer/src_test_runner.chloro.rs
+++ b/chloro-core/tests/conformance/snapshots/ra/rust_analyzer/src_test_runner.chloro.rs
@@ -20,6 +20,7 @@ pub(crate) enum TestState {
     Ok,
     Ignored,
     Failed {
+        // the stdout field is not always present depending on cargo test flags
         #[serde(skip_serializing_if = "String::is_empty", default)]
         stdout: String,
     },

--- a/chloro-core/tests/conformance/snapshots/ra/rust_analyzer/src_test_runner.diff
+++ b/chloro-core/tests/conformance/snapshots/ra/rust_analyzer/src_test_runner.diff
@@ -2,19 +2,12 @@ COMPARISON DIFF
 ============================================================
 
 Original size: 4244 bytes
-Chloro size:   4165 bytes
+Chloro size:   4245 bytes
 Rustfmt size:  4381 bytes
 
 ✗ Outputs DIFFER
 
 === DIFF (- rustfmt, + chloro) ===
-     Ok,
-     Ignored,
-     Failed {
--        // the stdout field is not always present depending on cargo test flags
-         #[serde(skip_serializing_if = "String::is_empty", default)]
-         stdout: String,
-     },
  
  impl CargoTestOutputParser {
      pub(crate) fn new(test_target: &TestTarget) -> Self {

--- a/chloro/README.md
+++ b/chloro/README.md
@@ -32,7 +32,7 @@ as tested on rust-analyzer's [crates][ra-crates]:
 [ra-crates]: https://github.com/rust-lang/rust-analyzer/blob/master/crates/syntax/src/ast/generated.rs
 
 <!-- just: conf-md -->
-**Summary:** +94,950 / -13,609
+**Summary:** +94,024 / -13,420
 
 | **Top 5 <del>Removed</del> Lines** | **Top 5 <ins>Added</ins> Lines** |
 |---|---|
@@ -42,23 +42,23 @@ as tested on rust-analyzer's [crates][ra-crates]:
 
 | Rank | Size Rank | Diff Rank | Impact |   +   |    -    | File |
 |------|-----------|-----------|--------|-------|---------|------|
-| 1 | 7 | 1 | 41.0% | 1,561 | 3,808 | [`rust_analyzer/src_config`](https://github.com/lmmx/chloro/blob/master/chloro-core/tests/conformance/snapshots/ra/rust_analyzer/src_config.diff) |
-| 2 | 2 | 11 | 3.9% | 248 | 6,437 | [`hir/src_lib`](https://github.com/lmmx/chloro/blob/master/chloro-core/tests/conformance/snapshots/ra/hir/src_lib.diff) |
+| 1 | 7 | 1 | 40.9% | 1,559 | 3,814 | [`rust_analyzer/src_config`](https://github.com/lmmx/chloro/blob/master/chloro-core/tests/conformance/snapshots/ra/rust_analyzer/src_config.diff) |
+| 2 | 2 | 11 | 3.8% | 245 | 6,440 | [`hir/src_lib`](https://github.com/lmmx/chloro/blob/master/chloro-core/tests/conformance/snapshots/ra/hir/src_lib.diff) |
 | 3 | 1 | 33 | 1.5% | 165 | 11,159 | [`ide/src_hover_tests`](https://github.com/lmmx/chloro/blob/master/chloro-core/tests/conformance/snapshots/ra/ide/src_hover_tests.diff) |
-| 4 | 3 | 17 | 3.6% | 216 | 6,084 | [`ide_assists/src_handlers_extract_function`](https://github.com/lmmx/chloro/blob/master/chloro-core/tests/conformance/snapshots/ra/ide_assists/src_handlers_extract_function.diff) |
+| 4 | 3 | 16 | 3.6% | 216 | 6,084 | [`ide_assists/src_handlers_extract_function`](https://github.com/lmmx/chloro/blob/master/chloro-core/tests/conformance/snapshots/ra/ide_assists/src_handlers_extract_function.diff) |
 | 5 | 15 | 5 | 12.4% | 373 | 3,020 | [`rust_analyzer/src_lsp_to_proto`](https://github.com/lmmx/chloro/blob/master/chloro-core/tests/conformance/snapshots/ra/rust_analyzer/src_lsp_to_proto.diff) |
-| 6 | 60 | 2 | 53.4% | 798 | 1,495 | [`hir_expand/src_builtin_derive_macro`](https://github.com/lmmx/chloro/blob/master/chloro-core/tests/conformance/snapshots/ra/hir_expand/src_builtin_derive_macro.diff) |
-| 7 | 6 | 20 | 5.1% | 201 | 3,916 | [`ide/src_goto_definition`](https://github.com/lmmx/chloro/blob/master/chloro-core/tests/conformance/snapshots/ra/ide/src_goto_definition.diff) |
+| 6 | 6 | 19 | 5.1% | 201 | 3,916 | [`ide/src_goto_definition`](https://github.com/lmmx/chloro/blob/master/chloro-core/tests/conformance/snapshots/ra/ide/src_goto_definition.diff) |
+| 7 | 60 | 2 | 53.4% | 798 | 1,495 | [`hir_expand/src_builtin_derive_macro`](https://github.com/lmmx/chloro/blob/master/chloro-core/tests/conformance/snapshots/ra/hir_expand/src_builtin_derive_macro.diff) |
 | 8 | 29 | 6 | 15.0% | 346 | 2,313 | [`hir_ty/src_next_solver_interner`](https://github.com/lmmx/chloro/blob/master/chloro-core/tests/conformance/snapshots/ra/hir_ty/src_next_solver_interner.diff) |
 | 9 | 89 | 3 | 37.3% | 428 | 1,147 | [`ide/src_navigation_target`](https://github.com/lmmx/chloro/blob/master/chloro-core/tests/conformance/snapshots/ra/ide/src_navigation_target.diff) |
-| 10 | 68 | 4 | 30.7% | 422 | 1,373 | [`hir_def/src_lib`](https://github.com/lmmx/chloro/blob/master/chloro-core/tests/conformance/snapshots/ra/hir_def/src_lib.diff) |
+| 10 | 67 | 4 | 30.5% | 419 | 1,376 | [`hir_def/src_lib`](https://github.com/lmmx/chloro/blob/master/chloro-core/tests/conformance/snapshots/ra/hir_def/src_lib.diff) |
 | 11 | 41 | 7 | 17.8% | 335 | 1,882 | [`ide_assists/src_handlers_auto_import`](https://github.com/lmmx/chloro/blob/master/chloro-core/tests/conformance/snapshots/ra/ide_assists/src_handlers_auto_import.diff) |
 | 12 | 8 | 38 | 4.0% | 152 | 3,788 | [`ide/src_rename`](https://github.com/lmmx/chloro/blob/master/chloro-core/tests/conformance/snapshots/ra/ide/src_rename.diff) |
 | 13 | 14 | 31 | 5.6% | 171 | 3,066 | [`ide/src_references`](https://github.com/lmmx/chloro/blob/master/chloro-core/tests/conformance/snapshots/ra/ide/src_references.diff) |
-| 14 | 33 | 19 | 9.3% | 204 | 2,197 | [`ide_assists/src_handlers_add_missing_match_arms`](https://github.com/lmmx/chloro/blob/master/chloro-core/tests/conformance/snapshots/ra/ide_assists/src_handlers_add_missing_match_arms.diff) |
-| 15 | 13 | 56 | 4.0% | 124 | 3,099 | [`ide_assists/src_handlers_generate_function`](https://github.com/lmmx/chloro/blob/master/chloro-core/tests/conformance/snapshots/ra/ide_assists/src_handlers_generate_function.diff) |
+| 14 | 33 | 17 | 9.3% | 204 | 2,197 | [`ide_assists/src_handlers_add_missing_match_arms`](https://github.com/lmmx/chloro/blob/master/chloro-core/tests/conformance/snapshots/ra/ide_assists/src_handlers_add_missing_match_arms.diff) |
+| 15 | 13 | 57 | 4.0% | 123 | 3,100 | [`ide_assists/src_handlers_generate_function`](https://github.com/lmmx/chloro/blob/master/chloro-core/tests/conformance/snapshots/ra/ide_assists/src_handlers_generate_function.diff) |
 | 16 | 95 | 8 | 24.4% | 273 | 1,121 | [`rust_analyzer/tests_slow-tests_ratoml`](https://github.com/lmmx/chloro/blob/master/chloro-core/tests/conformance/snapshots/ra/rust_analyzer/tests_slow-tests_ratoml.diff) |
-| 17 | 44 | 21 | 10.5% | 193 | 1,838 | [`ide_assists/src_handlers_generate_delegate_trait`](https://github.com/lmmx/chloro/blob/master/chloro-core/tests/conformance/snapshots/ra/ide_assists/src_handlers_generate_delegate_trait.diff) |
+| 17 | 44 | 20 | 10.5% | 193 | 1,838 | [`ide_assists/src_handlers_generate_delegate_trait`](https://github.com/lmmx/chloro/blob/master/chloro-core/tests/conformance/snapshots/ra/ide_assists/src_handlers_generate_delegate_trait.diff) |
 | 18 | 19 | 50 | 5.0% | 132 | 2,635 | [`ide_assists/src_handlers_extract_variable`](https://github.com/lmmx/chloro/blob/master/chloro-core/tests/conformance/snapshots/ra/ide_assists/src_handlers_extract_variable.diff) |
 | 19 | 37 | 28 | 8.6% | 174 | 2,034 | [`ide_assists/src_handlers_destructure_tuple_binding`](https://github.com/lmmx/chloro/blob/master/chloro-core/tests/conformance/snapshots/ra/ide_assists/src_handlers_destructure_tuple_binding.diff) |
 | 20 | 11 | 97 | 2.8% | 90 | 3,270 | [`ide_completion/src_render`](https://github.com/lmmx/chloro/blob/master/chloro-core/tests/conformance/snapshots/ra/ide_completion/src_render.diff) |


### PR DESCRIPTION
Great progress on avoiding comment loss
